### PR TITLE
Add rule for services modifying their internal state

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -20,6 +20,10 @@ services:
 		tags:
 			- phpstan.rules.rule
 	-
+		class: PHPStan\Rules\Symfony\ModifiedServiceStateRule
+		tags:
+			- phpstan.rules.rule
+	-
 		class: PHPStan\Type\Symfony\ContainerInterfaceMethodTypeSpecifyingExtension
 		tags:
 			- phpstan.typeSpecifier.methodTypeSpecifyingExtension

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -1,0 +1,106 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Rules\Symfony;
+
+use PhpParser\Node;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Symfony\ServiceMap;
+use PHPStan\Type\TypeUtils;
+
+class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
+{
+    /** @var ServiceMap */
+    private $serviceMap;
+
+    public function __construct(ServiceMap $symfonyServiceMap)
+    {
+        $this->serviceMap = $symfonyServiceMap;
+    }
+
+    public function getNodeType(): string
+    {
+        return ClassMethod::class;
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\ClassMethod $node
+     * @param \PHPStan\Analyser\Scope $scope
+     * @return string[]
+     * @throws \PHPStan\ShouldNotHappenException
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$scope->isInClass()) {
+            throw new \PHPStan\ShouldNotHappenException();
+        }
+        if ($node->name->name === '__construct') {
+            return [];
+        }
+        $classReflection = $scope->getClassReflection()->getNativeReflection();
+        if ($classReflection->isInterface() || $classReflection->isAnonymous()) {
+            return [];
+        }
+        if ($this->isSymfonyService($scope) &&
+            !$this->isDependencyInjectionMethod($node, $scope) &&
+            $this->modifiesInternalState($node, $scope)) {
+            return [
+                sprintf(
+                    '%s->%s modifies internal state of a Symfony service',
+                    $classReflection->getName(),
+                    (string)$node->name
+                ),
+            ];
+        }
+
+        return [];
+    }
+
+    private function isSymfonyService(Scope $scope): bool
+    {
+        $serviceId = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+
+        return $serviceId != null && count($serviceId) > 0;
+    }
+
+    private function isDependencyInjectionMethod(Node $parserNode, Scope $scope): bool
+    {
+        $serviceIds = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+        foreach ($serviceIds as $serviceId) {
+            $service = $this->serviceMap->getService($serviceId);
+            foreach ($service->getMethodCalls() as $curMethodCall) {
+                if ($curMethodCall == $parserNode->name) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function modifiesInternalState(Node $parserNode, Scope $scope): bool
+    {
+        if (!isset($parserNode->stmts)) {
+            return false;
+        }
+        foreach ($parserNode->stmts as $statement) {
+            if ($statement instanceof Node\Stmt\Expression) {
+                $statement = $statement->expr;
+            }
+            if ($statement instanceof \PhpParser\Node\Expr\Assign) {
+                if ($statement->var instanceof \PhpParser\Node\Expr\PropertyFetch) {
+                    if (@!$parserNode->name) { // Can be PhpParser\Node\Stmt\If_ that has no name
+                        return false;
+                    }
+
+                    return true;
+                }
+            } elseif ($this->modifiesInternalState($statement, $scope)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -10,96 +10,96 @@ use PHPStan\Symfony\ServiceMap;
 class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 {
 
-    /** @var ServiceMap */
-    private $serviceMap;
+	/** @var ServiceMap */
+	private $serviceMap;
 
-    public function __construct(ServiceMap $symfonyServiceMap)
-    {
-        $this->serviceMap = $symfonyServiceMap;
-    }
+	public function __construct(ServiceMap $symfonyServiceMap)
+	{
+		$this->serviceMap = $symfonyServiceMap;
+	}
 
-    public function getNodeType(): string
-    {
-        return ClassMethod::class;
-    }
+	public function getNodeType(): string
+	{
+		return ClassMethod::class;
+	}
 
-    /**
-     * @param \PhpParser\Node\Stmt\ClassMethod $node
-     * @param \PHPStan\Analyser\Scope $scope
-     * @return string[]
-     * @throws \PHPStan\ShouldNotHappenException
-     */
-    public function processNode(Node $node, Scope $scope): array
-    {
-        if (!$scope->isInClass()) {
-            throw new \PHPStan\ShouldNotHappenException();
-        }
-        if ($node->name->name === '__construct') {
-            return [];
-        }
-        $classReflection = $scope->getClassReflection()->getNativeReflection();
-        if ($classReflection->isInterface() || $classReflection->isAnonymous()) {
-            return [];
-        }
-        if ($this->isSymfonyService($scope) &&
-            !$this->isDependencyInjectionMethod($node, $scope) &&
-            $this->modifiesInternalState($node, $scope)) {
-            return [
-                sprintf(
-                    '%s->%s modifies internal state of a Symfony service',
-                    $classReflection->getName(),
-                    (string)$node->name
-                ),
-            ];
-        }
+	/**
+	 * @param \PhpParser\Node\Stmt\ClassMethod $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return string[]
+	 * @throws \PHPStan\ShouldNotHappenException
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$scope->isInClass()) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+		if ($node->name->name === '__construct') {
+			return [];
+		}
+		$classReflection = $scope->getClassReflection()->getNativeReflection();
+		if ($classReflection->isInterface() || $classReflection->isAnonymous()) {
+			return [];
+		}
+		if ($this->isSymfonyService($scope) &&
+			!$this->isDependencyInjectionMethod($node, $scope) &&
+			$this->modifiesInternalState($node, $scope)) {
+			return [
+				sprintf(
+					'%s->%s modifies internal state of a Symfony service',
+					$classReflection->getName(),
+					(string)$node->name
+				),
+			];
+		}
 
-        return [];
-    }
+		return [];
+	}
 
-    private function isSymfonyService(Scope $scope): bool
-    {
-        $serviceId = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+	private function isSymfonyService(Scope $scope): bool
+	{
+		$serviceId = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
 
-        return $serviceId != null && count($serviceId) > 0;
-    }
+		return $serviceId != null && count($serviceId) > 0;
+	}
 
-    private function isDependencyInjectionMethod(Node $parserNode, Scope $scope): bool
-    {
-        $serviceIds = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
-        foreach ($serviceIds as $serviceId) {
-            $service = $this->serviceMap->getService($serviceId);
-            foreach ($service->getMethodCalls() as $curMethodCall) {
-                if ($curMethodCall == $parserNode->name) {
-                    return true;
-                }
-            }
-        }
+	private function isDependencyInjectionMethod(Node $parserNode, Scope $scope): bool
+	{
+		$serviceIds = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+		foreach ($serviceIds as $serviceId) {
+			$service = $this->serviceMap->getService($serviceId);
+			foreach ($service->getMethodCalls() as $curMethodCall) {
+				if ($curMethodCall == $parserNode->name) {
+					return true;
+				}
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 
-    private function modifiesInternalState(Node $parserNode, Scope $scope): bool
-    {
-        if (!isset($parserNode->stmts)) {
-            return false;
-        }
-        foreach ($parserNode->stmts as $statement) {
-            if ($statement instanceof Node\Stmt\Expression) {
-                $statement = $statement->expr;
-            }
-            if ($statement instanceof \PhpParser\Node\Expr\Assign) {
-                if ($statement->var instanceof \PhpParser\Node\Expr\PropertyFetch) {
-                    if (@!$parserNode->name) { // Can be PhpParser\Node\Stmt\If_ that has no name
-                        return false;
-                    }
+	private function modifiesInternalState(Node $parserNode, Scope $scope): bool
+	{
+		if (!isset($parserNode->stmts)) {
+			return false;
+		}
+		foreach ($parserNode->stmts as $statement) {
+			if ($statement instanceof Node\Stmt\Expression) {
+				$statement = $statement->expr;
+			}
+			if ($statement instanceof \PhpParser\Node\Expr\Assign) {
+				if ($statement->var instanceof \PhpParser\Node\Expr\PropertyFetch) {
+					if (@!$parserNode->name) { // Can be PhpParser\Node\Stmt\If_ that has no name
+						return false;
+					}
 
-                    return true;
-                }
-            } elseif ($this->modifiesInternalState($statement, $scope)) {
-                return true;
-            }
-        }
+					return true;
+				}
+			} elseif ($this->modifiesInternalState($statement, $scope)) {
+				return true;
+			}
+		}
 
-        return false;
-    }
+		return false;
+	}
 }

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -1,16 +1,15 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Rules\Symfony;
 
 use PhpParser\Node;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Symfony\ServiceMap;
-use PHPStan\Type\TypeUtils;
 
 class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 {
+
     /** @var ServiceMap */
     private $serviceMap;
 

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -48,7 +48,7 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 				sprintf(
 					'%s->%s modifies internal state of a Symfony service',
 					$classReflection->getName(),
-					(string)$node->name
+					(string) $node->name
 				),
 			];
 		}
@@ -60,7 +60,7 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 	{
 		$serviceId = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
 
-		return $serviceId != null && count($serviceId) > 0;
+		return $serviceId !== null && count($serviceId) > 0;
 	}
 
 	private function isDependencyInjectionMethod(Node $parserNode, Scope $scope): bool
@@ -69,7 +69,7 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 		foreach ($serviceIds as $serviceId) {
 			$service = $this->serviceMap->getService($serviceId);
 			foreach ($service->getMethodCalls() as $curMethodCall) {
-				if ($curMethodCall == $parserNode->name) {
+				if ($curMethodCall === $parserNode->name) {
 					return true;
 				}
 			}
@@ -102,4 +102,5 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 
 		return false;
 	}
+
 }

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -75,7 +75,7 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 		}
 		foreach ($serviceIds as $serviceId) {
 			$service = $this->serviceMap->getService($serviceId);
-			if ($service == null) {
+			if ($service === null) {
 				continue;
 			}
 			foreach ($service->getMethodCalls() as $curMethodCall) {

--- a/src/Rules/Symfony/ModifiedServiceStateRule.php
+++ b/src/Rules/Symfony/ModifiedServiceStateRule.php
@@ -37,13 +37,17 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 		if ($node->name->name === '__construct') {
 			return [];
 		}
+		if ($scope->getClassReflection() === null) {
+			return [];
+		}
 		$classReflection = $scope->getClassReflection()->getNativeReflection();
+		$classname = $scope->getClassReflection()->getName();
 		if ($classReflection->isInterface() || $classReflection->isAnonymous()) {
 			return [];
 		}
-		if ($this->isSymfonyService($scope) &&
-			!$this->isDependencyInjectionMethod($node, $scope) &&
-			$this->modifiesInternalState($node, $scope)) {
+		if ($this->isSymfonyService($classname) &&
+			!$this->isDependencyInjectionMethod($node, $classname) &&
+			$this->modifiesInternalState($node)) {
 			return [
 				sprintf(
 					'%s->%s modifies internal state of a Symfony service',
@@ -56,19 +60,28 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 		return [];
 	}
 
-	private function isSymfonyService(Scope $scope): bool
+	private function isSymfonyService(string $classname): bool
 	{
-		$serviceId = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+		$serviceId = $this->serviceMap->getServiceIdsFromClassname($classname);
 
 		return $serviceId !== null && count($serviceId) > 0;
 	}
 
-	private function isDependencyInjectionMethod(Node $parserNode, Scope $scope): bool
+	private function isDependencyInjectionMethod(Node $parserNode, string $classname): bool
 	{
-		$serviceIds = $this->serviceMap->getServiceIdsFromClassname($scope->getClassReflection()->getName());
+		$serviceIds = $this->serviceMap->getServiceIdsFromClassname($classname);
+		if ($serviceIds === null) {
+			return false;
+		}
 		foreach ($serviceIds as $serviceId) {
 			$service = $this->serviceMap->getService($serviceId);
+			if ($service == null) {
+				continue;
+			}
 			foreach ($service->getMethodCalls() as $curMethodCall) {
+				if (!isset($parserNode->name)) { // Can be PhpParser\Node\Stmt\If_ that has no name
+					continue;
+				}
 				if ($curMethodCall === $parserNode->name) {
 					return true;
 				}
@@ -78,7 +91,7 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 		return false;
 	}
 
-	private function modifiesInternalState(Node $parserNode, Scope $scope): bool
+	private function modifiesInternalState(Node $parserNode): bool
 	{
 		if (!isset($parserNode->stmts)) {
 			return false;
@@ -89,13 +102,13 @@ class ModifiedServiceStateRule implements \PHPStan\Rules\Rule
 			}
 			if ($statement instanceof \PhpParser\Node\Expr\Assign) {
 				if ($statement->var instanceof \PhpParser\Node\Expr\PropertyFetch) {
-					if (@!$parserNode->name) { // Can be PhpParser\Node\Stmt\If_ that has no name
+					if (!isset($parserNode->name)) { // Can be PhpParser\Node\Stmt\If_ that has no name
 						return false;
 					}
 
 					return true;
 				}
-			} elseif ($this->modifiesInternalState($statement, $scope)) {
+			} elseif ($this->modifiesInternalState($statement)) {
 				return true;
 			}
 		}

--- a/src/Symfony/Service.php
+++ b/src/Symfony/Service.php
@@ -33,7 +33,7 @@ final class Service
 		bool $synthetic,
 		?string $alias,
 		bool $hidden,
-        array $methodCalls
+		array $methodCalls
 	)
 	{
 		$this->id = $id;
@@ -76,8 +76,8 @@ final class Service
 	}
 
 	public function getMethodCalls(): array
-    {
-        return $this->methodCalls;
-    }
+	{
+		return $this->methodCalls;
+	}
 
 }

--- a/src/Symfony/Service.php
+++ b/src/Symfony/Service.php
@@ -23,9 +23,10 @@ final class Service
 	/** @var bool */
 	private $hidden;
 
-	/** @var array */
+	/** @var string[] */
 	private $methodCalls;
 
+	/** @param string[] $methodCalls */
 	public function __construct(
 		string $id,
 		?string $class,
@@ -75,6 +76,7 @@ final class Service
 		return $this->hidden;
 	}
 
+	/** @return string[] */
 	public function getMethodCalls(): array
 	{
 		return $this->methodCalls;

--- a/src/Symfony/Service.php
+++ b/src/Symfony/Service.php
@@ -23,13 +23,17 @@ final class Service
 	/** @var bool */
 	private $hidden;
 
+	/** @var array */
+	private $methodCalls;
+
 	public function __construct(
 		string $id,
 		?string $class,
 		bool $public,
 		bool $synthetic,
 		?string $alias,
-		bool $hidden
+		bool $hidden,
+        array $methodCalls
 	)
 	{
 		$this->id = $id;
@@ -38,6 +42,7 @@ final class Service
 		$this->synthetic = $synthetic;
 		$this->alias = $alias;
 		$this->hidden = $hidden;
+		$this->methodCalls = $methodCalls;
 	}
 
 	public function getId(): string
@@ -69,5 +74,10 @@ final class Service
 	{
 		return $this->hidden;
 	}
+
+	public function getMethodCalls(): array
+    {
+        return $this->methodCalls;
+    }
 
 }

--- a/src/Symfony/Service.php
+++ b/src/Symfony/Service.php
@@ -26,7 +26,15 @@ final class Service
 	/** @var string[] */
 	private $methodCalls;
 
-	/** @param string[] $methodCalls */
+	/**
+	 * @param string $id
+	 * @param string|null $class
+	 * @param bool $public
+	 * @param bool $synthetic
+	 * @param string|null $alias
+	 * @param bool $hidden
+	 * @param string[] $methodCalls
+	 */
 	public function __construct(
 		string $id,
 		?string $class,

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Symfony;
 
@@ -9,89 +9,89 @@ use PHPStan\Type\TypeUtils;
 final class ServiceMap
 {
 
-    /** @var Service[] */
-    private $services = [];
-    private $serviceClasses = [];
+	/** @var Service[] */
+	private $services = [];
+	private $serviceClasses = [];
 
-    public function __construct(string $containerXml)
-    {
-        /** @var Service[] $aliases */
-        $aliases = [];
-        /** @var \SimpleXMLElement|false $xml */
-        $xml = @simplexml_load_file($containerXml);
-        if ($xml === false) {
-            throw new \PHPStan\Symfony\XmlContainerNotExistsException(
-                sprintf('Container %s not exists', $containerXml)
-            );
-        }
-        foreach ($xml->services->service as $def) {
-            $attrs = $def->attributes();
-            if (!isset($attrs->id)) {
-                continue;
-            }
-            $serviceId = strpos((string)$attrs->id, '.') === 0 ? substr((string)$attrs->id, 1) : (string)$attrs->id;
-            $service = new Service(
-                $serviceId,
-                isset($attrs->class) ? (string)$attrs->class : null,
-                !isset($attrs->public) || (string)$attrs->public !== 'false',
-                isset($attrs->synthetic) && (string)$attrs->synthetic === 'true',
-                isset($attrs->alias) ? (string)$attrs->alias : null,
-                strpos((string)$attrs->id, '.') === 0,
-                $this->getMethodCalls($def)
-            );
-            if ($service->getAlias() !== null) {
-                $aliases[] = $service;
-            } else {
-                $this->services[$service->getId()] = $service;
-            }
-            if (isset($attrs->class)) {
-                $this->serviceClasses[(string)$attrs->class][] = $serviceId;
-            }
-        }
-        foreach ($aliases as $service) {
-            if ($service->getAlias() !== null && !array_key_exists($service->getAlias(), $this->services)) {
-                continue;
-            }
-            $this->services[$service->getId()] = new Service(
-                $service->getId(),
-                $this->services[$service->getAlias()]->getClass(),
-                $service->isPublic(),
-                $service->isSynthetic(),
-                $service->getAlias(),
-                $service->isHidden(),
-                $service->getMethodCalls()
-            );
-        }
-    }
+	public function __construct(string $containerXml)
+	{
+		/** @var Service[] $aliases */
+		$aliases = [];
+		/** @var \SimpleXMLElement|false $xml */
+		$xml = @simplexml_load_file($containerXml);
+		if ($xml === false) {
+			throw new \PHPStan\Symfony\XmlContainerNotExistsException(
+				sprintf('Container %s not exists', $containerXml)
+			);
+		}
+		foreach ($xml->services->service as $def) {
+			$attrs = $def->attributes();
+			if (!isset($attrs->id)) {
+				continue;
+			}
+			$serviceId = strpos((string)$attrs->id, '.') === 0 ? substr((string)$attrs->id, 1) : (string)$attrs->id;
+			$service = new Service(
+				$serviceId,
+				isset($attrs->class) ? (string)$attrs->class : null,
+				!isset($attrs->public) || (string)$attrs->public !== 'false',
+				isset($attrs->synthetic) && (string)$attrs->synthetic === 'true',
+				isset($attrs->alias) ? (string)$attrs->alias : null,
+				strpos((string)$attrs->id, '.') === 0,
+				$this->getMethodCalls($def)
+			);
+			if ($service->getAlias() !== null) {
+				$aliases[] = $service;
+			} else {
+				$this->services[$service->getId()] = $service;
+			}
+			if (isset($attrs->class)) {
+				$this->serviceClasses[(string)$attrs->class][] = $serviceId;
+			}
+		}
+		foreach ($aliases as $service) {
+			if ($service->getAlias() !== null && !array_key_exists($service->getAlias(), $this->services)) {
+				continue;
+			}
+			$this->services[$service->getId()] = new Service(
+				$service->getId(),
+				$this->services[$service->getAlias()]->getClass(),
+				$service->isPublic(),
+				$service->isSynthetic(),
+				$service->getAlias(),
+				$service->isHidden(),
+				$service->getMethodCalls()
+			);
+		}
+	}
 
-    private function getMethodCalls($def): array
-    {
-        $methodCalls = [];
-        foreach ($def as $type => $element) {
-            if ($type == 'call') {
-                $attrs = $element->attributes();
-                $methodCalls[] = (string)$attrs->method;
-            }
-        }
+	private function getMethodCalls($def): array
+	{
+		$methodCalls = [];
+		foreach ($def as $type => $element) {
+			if ($type == 'call') {
+				$attrs = $element->attributes();
+				$methodCalls[] = (string)$attrs->method;
+			}
+		}
 
-        return $methodCalls;
-    }
+		return $methodCalls;
+	}
 
-    public function getService(string $id): ?Service
-    {
-        return $this->services[$id] ?? null;
-    }
+	public function getService(string $id): ?Service
+	{
+		return $this->services[$id] ?? null;
+	}
 
-    public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
-    {
-        $strings = TypeUtils::getConstantStrings($scope->getType($node));
+	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
+	{
+		$strings = TypeUtils::getConstantStrings($scope->getType($node));
 
-        return count($strings) === 1 ? $strings[0]->getValue() : null;
-    }
+		return count($strings) === 1 ? $strings[0]->getValue() : null;
+	}
 
-    public function getServiceIdsFromClassname(string $classname): ?array
-    {
-        return @$this->serviceClasses[$classname];
-    }
+	public function getServiceIdsFromClassname(string $classname): ?array
+	{
+		return @$this->serviceClasses[$classname];
+	}
 
 }

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -12,7 +12,7 @@ final class ServiceMap
 	/** @var Service[] */
 	private $services = [];
 
-	/** @var string[] */
+	/** @var string[][] */
 	private $serviceClasses = [];
 
 	public function __construct(string $containerXml)
@@ -68,7 +68,7 @@ final class ServiceMap
 	}
 
 	/**
-	 * @param SimpleXMLElement $def
+	 * @param \SimpleXMLElement $def
 	 * @return string[]
 	 */
 	private function getMethodCalls(\SimpleXMLElement $def): array

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -66,11 +66,15 @@ final class ServiceMap
 		}
 	}
 
+	/**
+	* @param SimpleXMLElement $def
+	* @return string[]
+	*/
 	private function getMethodCalls($def): array
 	{
 		$methodCalls = [];
 		foreach ($def as $type => $element) {
-			if ($type == 'call') {
+			if ($type === 'call') {
 				$attrs = $element->attributes();
 				$methodCalls[] = (string) $attrs->method;
 			}
@@ -91,7 +95,10 @@ final class ServiceMap
 		return count($strings) === 1 ? $strings[0]->getValue() : null;
 	}
 
-	/** @return string[] */
+	/**
+	* @param string $classname
+	* @return string[]|null
+	*/
 	public function getServiceIdsFromClassname(string $classname): ?array
 	{
 		return @$this->serviceClasses[$classname];

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -67,10 +67,10 @@ final class ServiceMap
 	}
 
 	/**
-	* @param SimpleXMLElement $def
-	* @return string[]
-	*/
-	private function getMethodCalls($def): array
+	 * @param SimpleXMLElement $def
+	 * @return string[]
+	 */
+	private function getMethodCalls(\SimpleXMLElement $def): array
 	{
 		$methodCalls = [];
 		foreach ($def as $type => $element) {
@@ -96,9 +96,9 @@ final class ServiceMap
 	}
 
 	/**
-	* @param string $classname
-	* @return string[]|null
-	*/
+	 * @param string $classname
+	 * @return string[]|null
+	 */
 	public function getServiceIdsFromClassname(string $classname): ?array
 	{
 		return @$this->serviceClasses[$classname];

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -46,9 +46,10 @@ final class ServiceMap
 			} else {
 				$this->services[$service->getId()] = $service;
 			}
-			if (isset($attrs->class)) {
-				$this->serviceClasses[(string) $attrs->class][] = $serviceId;
+			if (!isset($attrs->class)) {
+				continue;
 			}
+			$this->serviceClasses[(string) $attrs->class][] = $serviceId;
 		}
 		foreach ($aliases as $service) {
 			if ($service->getAlias() !== null && !array_key_exists($service->getAlias(), $this->services)) {
@@ -74,10 +75,11 @@ final class ServiceMap
 	{
 		$methodCalls = [];
 		foreach ($def as $type => $element) {
-			if ($type === 'call') {
-				$attrs = $element->attributes();
-				$methodCalls[] = (string) $attrs->method;
+			if ($type !== 'call') {
+				continue;
 			}
+			$attrs = $element->attributes();
+			$methodCalls[] = (string) $attrs->method;
 		}
 
 		return $methodCalls;

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -11,6 +11,8 @@ final class ServiceMap
 
 	/** @var Service[] */
 	private $services = [];
+
+	/** @var string[] */
 	private $serviceClasses = [];
 
 	public function __construct(string $containerXml)
@@ -29,14 +31,14 @@ final class ServiceMap
 			if (!isset($attrs->id)) {
 				continue;
 			}
-			$serviceId = strpos((string)$attrs->id, '.') === 0 ? substr((string)$attrs->id, 1) : (string)$attrs->id;
+			$serviceId = strpos((string) $attrs->id, '.') === 0 ? substr((string) $attrs->id, 1) : (string) $attrs->id;
 			$service = new Service(
 				$serviceId,
-				isset($attrs->class) ? (string)$attrs->class : null,
-				!isset($attrs->public) || (string)$attrs->public !== 'false',
-				isset($attrs->synthetic) && (string)$attrs->synthetic === 'true',
-				isset($attrs->alias) ? (string)$attrs->alias : null,
-				strpos((string)$attrs->id, '.') === 0,
+				isset($attrs->class) ? (string) $attrs->class : null,
+				!isset($attrs->public) || (string) $attrs->public !== 'false',
+				isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
+				isset($attrs->alias) ? (string) $attrs->alias : null,
+				strpos((string) $attrs->id, '.') === 0,
 				$this->getMethodCalls($def)
 			);
 			if ($service->getAlias() !== null) {
@@ -45,7 +47,7 @@ final class ServiceMap
 				$this->services[$service->getId()] = $service;
 			}
 			if (isset($attrs->class)) {
-				$this->serviceClasses[(string)$attrs->class][] = $serviceId;
+				$this->serviceClasses[(string) $attrs->class][] = $serviceId;
 			}
 		}
 		foreach ($aliases as $service) {
@@ -70,7 +72,7 @@ final class ServiceMap
 		foreach ($def as $type => $element) {
 			if ($type == 'call') {
 				$attrs = $element->attributes();
-				$methodCalls[] = (string)$attrs->method;
+				$methodCalls[] = (string) $attrs->method;
 			}
 		}
 
@@ -89,6 +91,7 @@ final class ServiceMap
 		return count($strings) === 1 ? $strings[0]->getValue() : null;
 	}
 
+	/** @return string[] */
 	public function getServiceIdsFromClassname(string $classname): ?array
 	{
 		return @$this->serviceClasses[$classname];

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types = 1);
+<?php declare(strict_types=1);
 
 namespace PHPStan\Symfony;
 
@@ -9,61 +9,89 @@ use PHPStan\Type\TypeUtils;
 final class ServiceMap
 {
 
-	/** @var Service[] */
-	private $services = [];
+    /** @var Service[] */
+    private $services = [];
+    private $serviceClasses = [];
 
-	public function __construct(string $containerXml)
-	{
-		/** @var Service[] $aliases */
-		$aliases = [];
-		/** @var \SimpleXMLElement|false $xml */
-		$xml = @simplexml_load_file($containerXml);
-		if ($xml === false) {
-			throw new \PHPStan\Symfony\XmlContainerNotExistsException(sprintf('Container %s not exists', $containerXml));
-		}
-		foreach ($xml->services->service as $def) {
-			$attrs = $def->attributes();
-			if (!isset($attrs->id)) {
-				continue;
-			}
-			$service = new Service(
-				strpos((string) $attrs->id, '.') === 0 ? substr((string) $attrs->id, 1) : (string) $attrs->id,
-				isset($attrs->class) ? (string) $attrs->class : null,
-				!isset($attrs->public) || (string) $attrs->public !== 'false',
-				isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
-				isset($attrs->alias) ? (string) $attrs->alias : null,
-				strpos((string) $attrs->id, '.') === 0
-			);
-			if ($service->getAlias() !== null) {
-				$aliases[] = $service;
-			} else {
-				$this->services[$service->getId()] = $service;
-			}
-		}
-		foreach ($aliases as $service) {
-			if ($service->getAlias() !== null && !array_key_exists($service->getAlias(), $this->services)) {
-				continue;
-			}
-			$this->services[$service->getId()] = new Service(
-				$service->getId(),
-				$this->services[$service->getAlias()]->getClass(),
-				$service->isPublic(),
-				$service->isSynthetic(),
-				$service->getAlias(),
-				$service->isHidden()
-			);
-		}
-	}
+    public function __construct(string $containerXml)
+    {
+        /** @var Service[] $aliases */
+        $aliases = [];
+        /** @var \SimpleXMLElement|false $xml */
+        $xml = @simplexml_load_file($containerXml);
+        if ($xml === false) {
+            throw new \PHPStan\Symfony\XmlContainerNotExistsException(
+                sprintf('Container %s not exists', $containerXml)
+            );
+        }
+        foreach ($xml->services->service as $def) {
+            $attrs = $def->attributes();
+            if (!isset($attrs->id)) {
+                continue;
+            }
+            $serviceId = strpos((string)$attrs->id, '.') === 0 ? substr((string)$attrs->id, 1) : (string)$attrs->id;
+            $service = new Service(
+                $serviceId,
+                isset($attrs->class) ? (string)$attrs->class : null,
+                !isset($attrs->public) || (string)$attrs->public !== 'false',
+                isset($attrs->synthetic) && (string)$attrs->synthetic === 'true',
+                isset($attrs->alias) ? (string)$attrs->alias : null,
+                strpos((string)$attrs->id, '.') === 0,
+                $this->getMethodCalls($def)
+            );
+            if ($service->getAlias() !== null) {
+                $aliases[] = $service;
+            } else {
+                $this->services[$service->getId()] = $service;
+            }
+            if (isset($attrs->class)) {
+                $this->serviceClasses[(string)$attrs->class][] = $serviceId;
+            }
+        }
+        foreach ($aliases as $service) {
+            if ($service->getAlias() !== null && !array_key_exists($service->getAlias(), $this->services)) {
+                continue;
+            }
+            $this->services[$service->getId()] = new Service(
+                $service->getId(),
+                $this->services[$service->getAlias()]->getClass(),
+                $service->isPublic(),
+                $service->isSynthetic(),
+                $service->getAlias(),
+                $service->isHidden(),
+                $service->getMethodCalls()
+            );
+        }
+    }
 
-	public function getService(string $id): ?Service
-	{
-		return $this->services[$id] ?? null;
-	}
+    private function getMethodCalls($def): array
+    {
+        $methodCalls = [];
+        foreach ($def as $type => $element) {
+            if ($type == 'call') {
+                $attrs = $element->attributes();
+                $methodCalls[] = (string)$attrs->method;
+            }
+        }
 
-	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
-	{
-		$strings = TypeUtils::getConstantStrings($scope->getType($node));
-		return count($strings) === 1 ? $strings[0]->getValue() : null;
-	}
+        return $methodCalls;
+    }
+
+    public function getService(string $id): ?Service
+    {
+        return $this->services[$id] ?? null;
+    }
+
+    public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
+    {
+        $strings = TypeUtils::getConstantStrings($scope->getType($node));
+
+        return count($strings) === 1 ? $strings[0]->getValue() : null;
+    }
+
+    public function getServiceIdsFromClassname(string $classname): ?array
+    {
+        return @$this->serviceClasses[$classname];
+    }
 
 }

--- a/tests/Symfony/ServiceTest.php
+++ b/tests/Symfony/ServiceTest.php
@@ -9,13 +9,14 @@ final class ServiceTest extends TestCase
 
 	public function testGetSet(): void
 	{
-		$service = new Service('foo', 'Bar', true, true, 'alias', true);
+		$service = new Service('foo', 'Bar', true, true, 'alias', true, ['testMethod']);
 		self::assertSame('foo', $service->getId());
 		self::assertSame('Bar', $service->getClass());
 		self::assertTrue($service->isPublic());
 		self::assertTrue($service->isSynthetic());
 		self::assertSame('alias', $service->getAlias());
 		self::assertTrue($service->isHidden());
+		self::assertSame(['testMethod'], $service->getMethodCalls());
 	}
 
 }


### PR DESCRIPTION
With the arrival of different execution models like [PHP-PM](https://github.com/php-pm/php-pm) and [Roadrunner](https://github.com/spiral/roadrunner), the container and related services can no longer be guaranteed to be destroyed on every request. A common source of bugs in these scenarios, are services that modify their state (for example changing internal attributes when a method is called) without resetting it at the end of the request, assuming the service will be destroyed and reset.

Static analysis presents a good opportunity to catch these bugs and help make applications or libraries compatible with these models. For this reason I'm proposing to add a rule that detects changes to a service's internal state, if its outside the constructor or the method injections defined in the config.