### PR TITLE
Use spaces instead of tabs in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ And include extension.neon in your project's PHPStan config:
 
 ```
 includes:
-	- vendor/phpstan/phpstan-symfony/extension.neon
+    - vendor/phpstan/phpstan-symfony/extension.neon
 parameters:
-	symfony:
-		container_xml_path: %rootDir%/../../../var/cache/dev/appDevDebugProjectContainer.xml # or srcDevDebugProjectContainer.xml for Symfony 4+
+    symfony:
+        container_xml_path: %rootDir%/../../../var/cache/dev/appDevDebugProjectContainer.xml # or srcDevDebugProjectContainer.xml for Symfony 4+
 ```
 
 ## Limitations


### PR DESCRIPTION
of phpstan.neon cause tabs are not allowed and will result in an error after c&p this example and running phpstan.

Error message example:
```
Note: Using configuration file /var/www/html/phpstan.neon.dist.

In Decoder.php line 357:
                                                               
  Invalid combination of tabs and spaces on line 7, column 9. 
```