### PR TITLE
Disable PrivateServiceRule when the class implements ServiceSubscriberInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,4 +8,5 @@ parameters:
 		- */tests/tmp/*
 		- */tests/*/ExampleContainer.php
 		- */tests/*/ExampleController.php
+		- */tests/*/ExampleServiceSubscriber.php
 		- */tests/*/request_get_content.php

--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -50,6 +50,11 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 			return [];
 		}
 
+		$isServiceSubscriber = (new ObjectType('Symfony\Component\DependencyInjection\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
+		if ($isServiceSubscriber->yes()) {
+			return [];
+		}
+
 		$serviceId = ServiceMap::getServiceIdFromNode($node->args[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
@@ -29,4 +29,18 @@ final class ContainerInterfacePrivateServiceRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testGetPrivateServiceInServiceSubscriber(): void
+	{
+		if (!interface_exists('Symfony\\Component\\DependencyInjection\\ServiceSubscriberInterface')) {
+			self::markTestSkipped('The test needs Symfony\Component\DependencyInjection\ServiceSubscriberInterface class.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleServiceSubscriber.php',
+			],
+			[]
+		);
+	}
+
 }

--- a/tests/Rules/Symfony/ExampleServiceSubscriber.php
+++ b/tests/Rules/Symfony/ExampleServiceSubscriber.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class ExampleServiceSubscriber extends AbstractController
+{
+
+	public function privateService(): void
+	{
+		$this->get('private');
+	}
+
+	public function privateServiceInTestContainer(): void
+	{
+		/** @var \Symfony\Bundle\FrameworkBundle\Test\TestContainer $container */
+		$container = doFoo();
+		$container->get('private');
+	}
+
+	public function unknownService(): void
+	{
+		$this->get('unknown');
+	}
+
+	public function unknownGuardedServiceInsideContext(): void
+	{
+		if ($this->has('unknown')) { // phpcs:ignore
+			$this->get('unknown');
+		}
+	}
+
+	public function unknownGuardedServiceOutsideOfContext(): void
+	{
+		if (!$this->has('unknown')) {
+			return;
+		}
+		$this->get('unknown');
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getSubscribedServices(): array
+	{
+		return [
+			'private' => MyService::class,
+		];
+	}
+
+}


### PR DESCRIPTION
I have a lot of violations `Service "X" is private.` when extending the `AbstractController` which implements the `ServiceSubscriberInterface`.

When implementing this interface, the service receive a special container with the services listed by the method `getSubscribedServices`.

I think the PrivateServiceRule should be disabled in this case.

(For details: https://symfony.com/doc/current/service_container/service_subscribers_locators.html)
