### PR TITLE
Update usage section for Symfony 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ includes:
 parameters:
 	symfony:
 		container_xml_path: %rootDir%/../../../var/cache/dev/srcDevDebugProjectContainer.xml
+		# or with Symfony 4.2+
+		container_xml_path: '%rootDir%/../../../var/cache/dev/srcApp_KernelDevDebugContainer.xml' 
 ```
 
 You have to provide a path to `srcDevDebugProjectContainer.xml` or similar xml file describing your container.


### PR DESCRIPTION
The filename of the dumped container has been changed in Symfony 4.2 (https://github.com/symfony/symfony/pull/28809/files#diff-50575470114d078b3ca3622ae30fba6eR431).