### PR TITLE
Honor new contracts namespace as-of Symfony 4.2 for ServiceSubscriberInterface

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ includes:
 parameters:
 	excludes_analyse:
 		- */tests/tmp/*
-		- */tests/*/ExampleContainer.php
-		- */tests/*/ExampleController.php
-		- */tests/*/ExampleServiceSubscriber.php
+		- */tests/*/Example*.php
+		- */tests/*/header_bag_get.php
 		- */tests/*/request_get_content.php
+		- */tests/*/serializer.php

--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -49,8 +49,9 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		$argType = $scope->getType($node->var);
 
 		$isTestContainerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Test\TestContainer'))->isSuperTypeOf($argType);
-		$isServiceSubscriber = (new ObjectType('Symfony\Component\DependencyInjection\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
-		if ($isTestContainerType->yes() || $isServiceSubscriber->yes()) {
+		$isOldServiceSubscriber = (new ObjectType('Symfony\Component\DependencyInjection\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
+		$isServiceSubscriber = (new ObjectType('Symfony\Contracts\Service\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
+		if ($isTestContainerType->yes() || $isOldServiceSubscriber->yes() || $isServiceSubscriber->yes()) {
 			return [];
 		}
 

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
@@ -29,7 +29,7 @@ final class ContainerInterfacePrivateServiceRuleTest extends RuleTestCase
 		);
 	}
 
-	public function testGetPrivateServiceInServiceSubscriber(): void
+	public function testGetPrivateServiceInLegacyServiceSubscriber(): void
 	{
 		if (!interface_exists('Symfony\\Component\\DependencyInjection\\ServiceSubscriberInterface')) {
 			self::markTestSkipped('The test needs Symfony\Component\DependencyInjection\ServiceSubscriberInterface class.');
@@ -37,7 +37,25 @@ final class ContainerInterfacePrivateServiceRuleTest extends RuleTestCase
 
 		$this->analyse(
 			[
+				__DIR__ . '/ExampleLegacyServiceSubscriber.php',
+				__DIR__ . '/ExampleLegacyServiceSubscriberFromAbstractController.php',
+				__DIR__ . '/ExampleLegacyServiceSubscriberFromLegacyController.php',
+			],
+			[]
+		);
+	}
+
+	public function testGetPrivateServiceInServiceSubscriber(): void
+	{
+		if (!interface_exists('Symfony\Contracts\Service\ServiceSubscriberInterface')) {
+			self::markTestSkipped('The test needs Symfony\Contracts\Service\ServiceSubscriberInterface class.');
+		}
+
+		$this->analyse(
+			[
 				__DIR__ . '/ExampleServiceSubscriber.php',
+				__DIR__ . '/ExampleServiceSubscriberFromAbstractController.php',
+				__DIR__ . '/ExampleServiceSubscriberFromLegacyController.php',
 			],
 			[]
 		);

--- a/tests/Rules/Symfony/ExampleLegacyServiceSubscriber.php
+++ b/tests/Rules/Symfony/ExampleLegacyServiceSubscriber.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
 final class ExampleLegacyServiceSubscriber implements ServiceSubscriberInterface
 {
+
 	public function privateService(): void
 	{
 		$this->get('private');

--- a/tests/Rules/Symfony/ExampleLegacyServiceSubscriber.php
+++ b/tests/Rules/Symfony/ExampleLegacyServiceSubscriber.php
@@ -2,11 +2,10 @@
 
 namespace PHPStan\Rules\Symfony;
 
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
-final class ExampleServiceSubscriber implements ServiceSubscriberInterface
+final class ExampleLegacyServiceSubscriber implements ServiceSubscriberInterface
 {
-
 	public function privateService(): void
 	{
 		$this->get('private');

--- a/tests/Rules/Symfony/ExampleLegacyServiceSubscriberFromAbstractController.php
+++ b/tests/Rules/Symfony/ExampleLegacyServiceSubscriberFromAbstractController.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+
+final class ExampleLegacyServiceSubscriberFromAbstractController extends AbstractController implements ServiceSubscriberInterface
+{
+
+	public function privateService(): void
+	{
+		$this->get('private');
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getSubscribedServices(): array
+	{
+		return [];
+	}
+
+}

--- a/tests/Rules/Symfony/ExampleLegacyServiceSubscriberFromLegacyController.php
+++ b/tests/Rules/Symfony/ExampleLegacyServiceSubscriberFromLegacyController.php
@@ -2,9 +2,10 @@
 
 namespace PHPStan\Rules\Symfony;
 
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
 
-final class ExampleServiceSubscriber implements ServiceSubscriberInterface
+final class ExampleLegacyServiceSubscriberFromLegacyController extends Controller implements ServiceSubscriberInterface
 {
 
 	public function privateService(): void

--- a/tests/Rules/Symfony/ExampleServiceSubscriberFromAbstractController.php
+++ b/tests/Rules/Symfony/ExampleServiceSubscriberFromAbstractController.php
@@ -2,9 +2,9 @@
 
 namespace PHPStan\Rules\Symfony;
 
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
-final class ExampleServiceSubscriber implements ServiceSubscriberInterface
+final class ExampleServiceSubscriberFromAbstractController extends AbstractController
 {
 
 	public function privateService(): void

--- a/tests/Rules/Symfony/ExampleServiceSubscriberFromLegacyController.php
+++ b/tests/Rules/Symfony/ExampleServiceSubscriberFromLegacyController.php
@@ -2,9 +2,10 @@
 
 namespace PHPStan\Rules\Symfony;
 
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
-final class ExampleServiceSubscriber implements ServiceSubscriberInterface
+final class ExampleServiceSubscriberFromLegacyController extends Controller implements ServiceSubscriberInterface
 {
 
 	public function privateService(): void


### PR DESCRIPTION
In Symfony 4.2 the ServiceSubscriberInterface has been moved into its own contracts namespace. This commit adds support for the new interface and adds more test-coverage for all possible cases/combinations.

This is a follow-up on #19 (https://github.com/phpstan/phpstan-symfony/commit/c340de842c656bdf5ea01eed07fce58ceb6eeb61)