### PR TITLE
Add support for Serializer::deserialize

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
     "slevomat/coding-standard": "^4.5.2",
     "phpstan/phpstan-phpunit": "^0.11",
     "symfony/framework-bundle": "^3.0 || ^4.0",
-    "squizlabs/php_codesniffer": "^3.3.2"
+    "squizlabs/php_codesniffer": "^3.3.2",
+    "symfony/serializer": "^3|^4"
   },
   "conflict": {
     "symfony/framework-bundle": "<3.0"

--- a/extension.neon
+++ b/extension.neon
@@ -45,3 +45,8 @@ services:
 	-
 		class: PHPStan\Type\Symfony\HeaderBagDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+	# SerializerInterface::deserialize() return type
+	-
+		class: PHPStan\Type\Symfony\SerializerInterfaceDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtension.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class SerializerInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Symfony\Component\Serializer\SerializerInterface';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'deserialize';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
+	{
+		$argType = $scope->getType($methodCall->args[1]->value);
+		if (!$argType instanceof ConstantStringType) {
+			return new MixedType();
+		}
+
+		$objectName = $argType->getValue();
+
+		if (substr($objectName, -2) === '[]') {
+			// The key type is determined by the data
+			return new ArrayType(new MixedType(false), new ObjectType(substr($objectName, 0, -2)));
+		}
+
+		return new ObjectType($objectName);
+	}
+
+}

--- a/tests/Symfony/NeonTest.php
+++ b/tests/Symfony/NeonTest.php
@@ -40,7 +40,7 @@ final class NeonTest extends TestCase
 		], $container->getParameters());
 
 		self::assertCount(2, $container->findByTag('phpstan.rules.rule'));
-		self::assertCount(5, $container->findByTag('phpstan.broker.dynamicMethodReturnTypeExtension'));
+		self::assertCount(6, $container->findByTag('phpstan.broker.dynamicMethodReturnTypeExtension'));
 		self::assertCount(3, $container->findByTag('phpstan.typeSpecifier.methodTypeSpecifyingExtension'));
 		self::assertInstanceOf(ServiceMap::class, $container->getByType(ServiceMap::class));
 	}

--- a/tests/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use Iterator;
+
+final class SerializerInterfaceDynamicReturnTypeExtensionTest extends ExtensionTestCase
+{
+
+	/**
+	 * @dataProvider getContentProvider
+	 */
+	public function testGetContent(string $expression, string $type): void
+	{
+		$this->processFile(
+			__DIR__ . '/serializer.php',
+			$expression,
+			$type,
+			new SerializerInterfaceDynamicReturnTypeExtension()
+		);
+	}
+
+	public function getContentProvider(): Iterator
+	{
+		yield ['$first', 'Bar'];
+		yield ['$second', 'array<Bar>'];
+	}
+
+}

--- a/tests/Type/Symfony/serializer.php
+++ b/tests/Type/Symfony/serializer.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+$serializer = new \Symfony\Component\Serializer\Serializer();
+
+$first = $serializer->deserialize('bar', 'Bar', 'format');
+$second = $serializer->deserialize('bar', 'Bar[]', 'format');
+
+die;


### PR DESCRIPTION
The return type of deserialize depends on the type you ask it for, so this gets us the correct type.