### PR TITLE
Add support for recursive types to Serializer

### DIFF
--- a/src/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtension.php
@@ -34,9 +34,14 @@ class SerializerInterfaceDynamicReturnTypeExtension implements DynamicMethodRetu
 
 		$objectName = $argType->getValue();
 
+		return $this->getType($objectName);
+	}
+
+	private function getType(string $objectName): Type
+	{
 		if (substr($objectName, -2) === '[]') {
 			// The key type is determined by the data
-			return new ArrayType(new MixedType(false), new ObjectType(substr($objectName, 0, -2)));
+			return new ArrayType(new MixedType(false), $this->getType(substr($objectName, 0, -2)));
 		}
 
 		return new ObjectType($objectName);

--- a/tests/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/SerializerInterfaceDynamicReturnTypeExtensionTest.php
@@ -24,6 +24,7 @@ final class SerializerInterfaceDynamicReturnTypeExtensionTest extends ExtensionT
 	{
 		yield ['$first', 'Bar'];
 		yield ['$second', 'array<Bar>'];
+		yield ['$third', 'array<array<Bar>>'];
 	}
 
 }

--- a/tests/Type/Symfony/serializer.php
+++ b/tests/Type/Symfony/serializer.php
@@ -4,5 +4,6 @@ $serializer = new \Symfony\Component\Serializer\Serializer();
 
 $first = $serializer->deserialize('bar', 'Bar', 'format');
 $second = $serializer->deserialize('bar', 'Bar[]', 'format');
+$third = $serializer->deserialize('bar', 'Bar[][]', 'format');
 
 die;


### PR DESCRIPTION
As correctly pointed out by @jvasseur, it's possible to have arrays of arrays.

https://github.com/phpstan/phpstan-symfony/pull/34#discussion_r256559742

Of course really we should check what normalizers are in the container, and only if ArrayNormalizer is active support this, and possibly be able to say what objects are deserializable, 