### PR TITLE
Separate rules from extension as in other phpstan extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,14 @@ parameters:
 		container_xml_path: '%rootDir%/../../../var/cache/dev/srcApp_KernelDevDebugContainer.xml' 
 ```
 
-You have to provide a path to `srcDevDebugProjectContainer.xml` or similar xml file describing your container.
+You have to provide a path to `srcApp_KernelDevDebugContainer.xml` or similar xml file describing your container.
+
+To perform framework-specific checks, include also this file:
+
+```
+includes:
+	- vendor/phpstan/phpstan-symfony/rules.neon
+```
 
 ## Constant hassers
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     },
     "phpstan": {
       "includes": [
-        "extension.neon"
+        "extension.neon",
+        "rules.neon"
       ]
     }
   },

--- a/extension.neon
+++ b/extension.neon
@@ -4,14 +4,6 @@ parameters:
 		constant_hassers: true
 		console_application_loader: null
 
-rules:
-	- PHPStan\Rules\Symfony\ContainerInterfacePrivateServiceRule
-	- PHPStan\Rules\Symfony\ContainerInterfaceUnknownServiceRule
-	- PHPStan\Rules\Symfony\UndefinedArgumentRule
-	- PHPStan\Rules\Symfony\InvalidArgumentDefaultValueRule
-	- PHPStan\Rules\Symfony\UndefinedOptionRule
-	- PHPStan\Rules\Symfony\InvalidOptionDefaultValueRule
-
 services:
 	# console resolver
 	-

--- a/rules.neon
+++ b/rules.neon
@@ -1,0 +1,7 @@
+rules:
+	- PHPStan\Rules\Symfony\ContainerInterfacePrivateServiceRule
+	- PHPStan\Rules\Symfony\ContainerInterfaceUnknownServiceRule
+	- PHPStan\Rules\Symfony\UndefinedArgumentRule
+	- PHPStan\Rules\Symfony\InvalidArgumentDefaultValueRule
+	- PHPStan\Rules\Symfony\UndefinedOptionRule
+	- PHPStan\Rules\Symfony\InvalidOptionDefaultValueRule


### PR DESCRIPTION
Doing this because issue of false positives in test cases, https://github.com/phpstan/phpstan-symfony/issues/27, but anyway, its the style in all the other phpstan plugins, so would be good to do the same here