### PR TITLE
Fix issue while loading a container

### DIFF
--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -2,7 +2,7 @@
 
 namespace PHPStan\Symfony;
 
-use function simplexml_load_file;
+use function simplexml_load_string;
 use function sprintf;
 use function strpos;
 use function substr;
@@ -20,7 +20,12 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 
 	public function create(): ServiceMap
 	{
-		$xml = @simplexml_load_file($this->containerXml);
+		$fileContents = file_get_contents($this->containerXml);
+		if ($fileContents === false) {
+			throw new XmlContainerNotExistsException(sprintf('Container %s does not exist or cannot be parsed', $this->containerXml));
+		}
+
+		$xml = @simplexml_load_string($fileContents);
 		if ($xml === false) {
 			throw new XmlContainerNotExistsException(sprintf('Container %s does not exist or cannot be parsed', $this->containerXml));
 		}

--- a/tests/Symfony/ServiceMapTest.php
+++ b/tests/Symfony/ServiceMapTest.php
@@ -17,6 +17,14 @@ final class ServiceMapTest extends TestCase
 		$validator($factory->create()->getService($id));
 	}
 
+	public function testGetContainerEscapedPath(): void
+	{
+		$factory = new XmlServiceMapFactory(__DIR__ . '/containers/bugfix%2Fcontainer.xml');
+		$serviceMap = $factory->create();
+
+		self::assertNotNull($serviceMap->getService('withClass'));
+	}
+
 	public function getServiceProvider(): Iterator
 	{
 		yield [

--- a/tests/Symfony/containers/bugfix%2Fcontainer.xml
+++ b/tests/Symfony/containers/bugfix%2Fcontainer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service></service><!-- without id -->
+    <service id="withoutClass"></service>
+    <service id="withClass" class="Foo"></service>
+    <service id="withoutPublic" class="Foo"></service>
+    <service id="publicNotFalse" class="Foo" public="true"></service>
+    <service id="private" class="Foo" public="false"></service>
+    <service id="synthetic" class="Foo" synthetic="true"></service>
+    <service id="alias" class="Bar" alias="withClass"></service>
+  </services>
+</container>


### PR DESCRIPTION
When the URI of the container contains escaped characters like `%2F`, `simplexml_load_file` throw an error.

~According [to the documentation](http://php.net/manual/en/function.simplexml-load-file.php) :~
> ~Libxml 2 unescapes the URI, so if you want to pass e.g. b&c as the URI parameter a, you have to call simplexml_load_file(rawurlencode('http://example.com/?a=' . urlencode('b&c'))). Since PHP 5.1.0 you don't need to do this because PHP will do it for you.~

~I don't understand exactly what should not be done since PHP 5.1.0, but with PHP 7.2, I reproduced the following error :~
```php
$jd = 'jdjd/test.xml';
$jdSlash = rawurlencode('jdjd/test.xml');
$jnSlash = rawurlencode('jn%2Fjn/test.xml');
$jn = 'jn%2Fjn/test.xml';

var_dump($jd); // string(13) "jdjd/test.xml"
var_dump(simplexml_load_file($jd)); // OK object(SimpleXMLElement) 

var_dump($jdSlash); // string(15) "jdjd%2Ftest.xml"
var_dump(simplexml_load_file($jdSlash)); // OK object(SimpleXMLElement) 

var_dump($jnSlash); // string(20) "jn%252Fjn%2Ftest.xml"
var_dump(simplexml_load_file($jnSlash)); // OK object(SimpleXMLElement)

var_dump($jn); // string(16) "jn%2Fjn/test.xml"
var_dump(simplexml_load_file($jn)); // PHP Warning:  simplexml_load_file(): I/O warning : failed to load external entity "jn%2Fjn/test.xml"
```

Another possible fix is to use:
```php
$xml = @simplexml_load_string(file_get_contents($this->containerXml));
```