### PR TITLE
`container_xml_path` for Symfony 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ parameters:
         container_xml_path: %rootDir%/../../../var/cache/dev/srcDevDebugProjectContainer.xml
         # or with Symfony 4.2+
         container_xml_path: '%rootDir%/../../../var/cache/dev/srcApp_KernelDevDebugContainer.xml'
+	# or with Symfony 5+
+	container_xml_path: '%rootDir%/../../../var/cache/dev/App_KernelDevDebugContainer.xml'
 ```
 
 ## Constant hassers


### PR DESCRIPTION
Added correct `container_xml_path` for Symfony 5