### PR TITLE
Add stubs for (some) Symfony iterable types

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -3,6 +3,11 @@ parameters:
 		container_xml_path: null
 		constant_hassers: true
 		console_application_loader: null
+	stubFiles:
+		- stubs/FormBuilderInterface.php
+		- stubs/FormInterface.php
+		- stubs/HeaderBag.php
+		- stubs/Session.php
 
 parametersSchema:
 	symfony: structure([

--- a/stubs/FormBuilderInterface.php
+++ b/stubs/FormBuilderInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+/**
+ * @extends \Traversable<int, \Symfony\Component\Form\FormBuilderInterface>
+ */
+interface FormBuilderInterface extends \Traversable
+{
+
+}

--- a/stubs/FormInterface.php
+++ b/stubs/FormInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+/**
+ * @extends \Traversable<int, \Symfony\Component\Form\FormInterface>
+ */
+interface FormInterface extends \Traversable
+{
+
+}

--- a/stubs/HeaderBag.php
+++ b/stubs/HeaderBag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * @implements \IteratorAggregate<string, string|string[]>
+ */
+class HeaderBag implements \IteratorAggregate
+{
+
+	/**
+	 * @phpstan-return \Traversable<string, string|string[]>
+	 */
+	public function getIterator() {}
+
+}

--- a/stubs/Session.php
+++ b/stubs/Session.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\Session;
+
+/**
+ * @implements \IteratorAggregate<string, mixed>
+ */
+class Session implements \IteratorAggregate
+{
+
+	/**
+	 * @phpstan-return \Traversable<string, mixed>
+	 */
+	public function getIterator() {}
+
+}


### PR DESCRIPTION
These are types where PHPStan on lvl 6 was complaining about missing iterable information (in our codebase) - there will be probably more, but I think especially the form ones are quite wide spread.

Original types for reference:

* [FormBuilderInterface](https://github.com/symfony/symfony/blob/v5.0.1/src/Symfony/Component/Form/FormBuilderInterface.php)
* [FormInterface](https://github.com/symfony/symfony/blob/v5.0.1/src/Symfony/Component/Form/FormInterface.php)
* [Session](https://github.com/symfony/symfony/blob/v5.0.1/src/Symfony/Component/HttpFoundation/Session/Session.php)
* [HeaderBag](https://github.com/symfony/symfony/blob/v5.0.1/src/Symfony/Component/HttpFoundation/HeaderBag.php)

As per discussion with @ondrejmirtes I am not adding any dependencies.
