### PR TITLE
Add a bunch of stubs

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -4,8 +4,15 @@ parameters:
 		constant_hassers: true
 		console_application_loader: null
 	stubFiles:
+		- stubs/ChoiceLoaderInterface.stub
+		- stubs/Constraint.stub
+		- stubs/ContainerBuilder.stub
+		- stubs/EventSubscriberInterface.stub
+		- stubs/ExtensionInterface.stub
 		- stubs/FormBuilderInterface.stub
 		- stubs/FormInterface.stub
+		- stubs/FormTypeInterface.stub
+		- stubs/FormView.stub
 		- stubs/HeaderBag.stub
 		- stubs/Session.stub
 

--- a/stubs/ChoiceLoaderInterface.stub
+++ b/stubs/ChoiceLoaderInterface.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Component\Form\ChoiceList\Loader;
+
+interface ChoiceLoaderInterface
+{
+    /**
+     * @param array<string> $values
+     * @param callable|null $value
+     *
+     * @return array<mixed>
+     */
+    public function loadChoicesForValues(array $values, $value = null);
+
+    /**
+     * @param array<mixed> $choices
+     * @param callable|null $value
+     *
+     * @return array<string>
+     */
+    public function loadValuesForChoices(array $choices, $value = null);
+}

--- a/stubs/Constraint.stub
+++ b/stubs/Constraint.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Validator;
+
+class Constraint
+{
+    /**
+     * @return array<mixed>
+     */
+    public function getRequiredOptions();
+
+    /**
+     * @return string|array<string>
+     */
+    public function getTargets();
+}

--- a/stubs/ContainerBuilder.stub
+++ b/stubs/ContainerBuilder.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection;
+
+class ContainerBuilder
+{
+}

--- a/stubs/EventSubscriberInterface.stub
+++ b/stubs/EventSubscriberInterface.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\EventDispatcher;
+
+interface EventSubscriberInterface
+{
+    /**
+     * @return array<string, string|array<string, int>|array<int, string|array<string, int>|array<int, string>>>
+     */
+    public static function getSubscribedEvents();
+}

--- a/stubs/ExtensionInterface.stub
+++ b/stubs/ExtensionInterface.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace Symfony\Component\DependencyInjection\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+interface ExtensionInterface
+{
+    /**
+     * @param array<mixed> $configs
+     */
+    public function load(array $configs, ContainerBuilder $container): void;
+}

--- a/stubs/FormTypeInterface.stub
+++ b/stubs/FormTypeInterface.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+interface FormTypeInterface
+{
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options): void;
+}

--- a/stubs/FormView.stub
+++ b/stubs/FormView.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+use ArrayAccess;
+use IteratorAggregate;
+
+/**
+ * @implements IteratorAggregate<string, self>
+ * @implements ArrayAccess<string, self>
+ */
+class FormView implements ArrayAccess, IteratorAggregate
+{
+}


### PR DESCRIPTION
Mostly adding `array<mixed>` where symfony documents `array` (phpstan will complain about this on max level when implementing these interfaces). 

Also added an "empty" `ContainerBuilder` stub, since phpstan complained about not knowing the class when seeing it in `ExtensionInterface.stub`. If there's another way to fix this please let me know.

These changes are based off of symfony 4.4 and tested on a medium to large-ish codebase.