### PR TITLE
Add stubs for various classes

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -7,13 +7,18 @@ parameters:
 		- stubs/ChoiceLoaderInterface.stub
 		- stubs/Constraint.stub
 		- stubs/ContainerBuilder.stub
+		- stubs/DataMapperInterface.stub
 		- stubs/EventSubscriberInterface.stub
 		- stubs/ExtensionInterface.stub
 		- stubs/FormBuilderInterface.stub
 		- stubs/FormInterface.stub
+		- stubs/FormTypeExtensionInterface.stub
 		- stubs/FormTypeInterface.stub
 		- stubs/FormView.stub
 		- stubs/HeaderBag.stub
+		- stubs/Node.stub
+		- stubs/NormalizerInterface.stub
+		- stubs/ParameterBag.stub
 		- stubs/Process.stub
 		- stubs/Session.stub
 

--- a/stubs/DataMapperInterface.stub
+++ b/stubs/DataMapperInterface.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+interface DataMapperInterface
+{
+    /**
+     * @param mixed $viewData
+     * @param \Traversable<\Symfony\Component\Form\FormInterface> $forms
+     */
+    public function mapDataToForms($viewData, $forms): void;
+
+    /**
+     * @param \Traversable<\Symfony\Component\Form\FormInterface> $forms
+     * @param mixed $viewData
+     */
+    public function mapFormsToData($forms, &$viewData): void;
+}

--- a/stubs/FormTypeExtensionInterface.stub
+++ b/stubs/FormTypeExtensionInterface.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+interface FormTypeExtensionInterface
+{
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options): void;
+}

--- a/stubs/Node.stub
+++ b/stubs/Node.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Node;
+
+/**
+ * @implements \IteratorAggregate<string, self>
+ */
+class Node implements \IteratorAggregate
+{
+
+}

--- a/stubs/NormalizerInterface.stub
+++ b/stubs/NormalizerInterface.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+interface NormalizerInterface
+{
+    /**
+     * @param mixed $object
+     * @param string $format
+     * @param mixed[] $context
+     *
+     * @return mixed[]|string|int|float|bool|null
+     */
+    public function normalize($object, $format = null, array $context = []);
+}

--- a/stubs/ParameterBag.stub
+++ b/stubs/ParameterBag.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * @implements \IteratorAggregate<string, mixed>
+ */
+class ParameterBag implements \IteratorAggregate
+{
+
+}


### PR DESCRIPTION
This adds stubs for:

* `Symfony\Component\Form\FormTypeExtensionInterface`
* `Symfony\Component\Serializer\Normalizer\NormalizerInterface`
* `Symfony\Component\HttpFoundation\ParameterBag`
* `Symfony\Component\Form\DataMapperInterface`

I also added a stub for `Twig\Node\Node`, however, if you think this is not a place for it, I will remove it. In that case, do you know if there's an official repo I can contribute to?