### PR TITLE
Add stub for KernelTestCase

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -14,6 +14,7 @@ parameters:
 		- stubs/FormTypeInterface.stub
 		- stubs/FormView.stub
 		- stubs/HeaderBag.stub
+		- stubs/KernelTestCase.stub
 		- stubs/Process.stub
 		- stubs/Session.stub
 

--- a/stubs/KernelTestCase.stub
+++ b/stubs/KernelTestCase.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+abstract class KernelTestCase {
+    /**
+     * @var TestContainer
+     */
+    protected static $container;
+}
+
+class TestContainer {}


### PR DESCRIPTION
This adds a stub for `Symfony\Bundle\FrameworkBundle\Test\KernelTestCase` to set the type of `$container` to `Symfony\Bundle\FrameworkBundle\Test\TestContainer` which in turn allows access to private services in tests as mentioned in https://github.com/phpstan/phpstan-symfony/issues/4