### PR TITLE
Fix InputBagDynamicReturnTypeExtension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "squizlabs/php_codesniffer": "^3.3.2",
     "symfony/console": "^4.0",
     "symfony/framework-bundle": "^4.0",
-    "symfony/http-foundation": "^4.0|^5.0",
+    "symfony/http-foundation": "^4.0 || ^5.0",
     "symfony/messenger": "^4.2",
     "symfony/serializer": "^4.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "squizlabs/php_codesniffer": "^3.3.2",
     "symfony/console": "^4.0",
     "symfony/framework-bundle": "^4.0",
-    "symfony/http-foundation": "^4.0",
+    "symfony/http-foundation": "^4.0|^5.0",
     "symfony/messenger": "^4.2",
     "symfony/serializer": "^4.0"
   },

--- a/extension.neon
+++ b/extension.neon
@@ -75,6 +75,11 @@ services:
 		factory: PHPStan\Type\Symfony\RequestTypeSpecifyingExtension
 		tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]
 
+	# InputBag::get() return type
+	-
+		factory: PHPStan\Type\Symfony\InputBagDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
 	# HeaderBag::get() return type
 	-
 		factory: PHPStan\Type\Symfony\HeaderBagDynamicReturnTypeExtension

--- a/src/Type/Symfony/InputBagDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputBagDynamicReturnTypeExtension.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+
+final class InputBagDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+	public function getClass(): string
+	{
+		return 'Symfony\Component\HttpFoundation\InputBag';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'get';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		if (isset($methodCall->args[1]) && $scope->getType($methodCall->args[1]->value) instanceof ConstantStringType) {
+			return new StringType();
+		}
+
+		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
+	}
+}

--- a/src/Type/Symfony/InputBagDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputBagDynamicReturnTypeExtension.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\Symfony;
 
@@ -13,6 +13,7 @@ use PHPStan\Type\Type;
 
 final class InputBagDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
+
 	public function getClass(): string
 	{
 		return 'Symfony\Component\HttpFoundation\InputBag';
@@ -41,4 +42,5 @@ final class InputBagDynamicReturnTypeExtension implements DynamicMethodReturnTyp
 
 		return ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType();
 	}
+
 }

--- a/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
@@ -29,9 +29,6 @@ final class InputBagDynamicReturnTypeExtensionTest extends ExtensionTestCase
 		yield ['$test2', 'string|null'];
 		yield ['$test3', 'string'];
 		yield ['$test4', 'string'];
-		yield ['$test5', 'string|null'];
-		yield ['$test6', 'string|null'];
-		yield ['$test7', 'string|null'];
 	}
 
 }

--- a/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace PHPStan\Type\Symfony;
 

--- a/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
@@ -29,6 +29,9 @@ final class InputBagDynamicReturnTypeExtensionTest extends ExtensionTestCase
 		yield ['$test2', 'string|null'];
 		yield ['$test3', 'string'];
 		yield ['$test4', 'string'];
+		yield ['$test5', 'string|null'];
+		yield ['$test6', 'string|null'];
+		yield ['$test7', 'string|null'];
 	}
 
 }

--- a/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace PHPStan\Type\Symfony;
+
+use Iterator;
+
+final class InputBagDynamicReturnTypeExtensionTest extends ExtensionTestCase
+{
+
+	/**
+	 * @dataProvider getProvider
+	 */
+	public function testGet(string $expression, string $type): void
+	{
+		$this->processFile(
+			__DIR__ . '/input_bag_get.php',
+			$expression,
+			$type,
+			new InputBagDynamicReturnTypeExtension()
+		);
+	}
+
+	/**
+	 * @return \Iterator<array{string, string}>
+	 */
+	public function getProvider(): Iterator
+	{
+		yield ['$test1', 'string|null'];
+		yield ['$test2', 'string|null'];
+		yield ['$test3', 'string'];
+		yield ['$test4', 'string'];
+	}
+
+}

--- a/tests/Type/Symfony/input_bag_get.php
+++ b/tests/Type/Symfony/input_bag_get.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+$bag = new \Symfony\Component\HttpFoundation\InputBag(['foo' => 'bar']);
+
+$test1 = $bag->get('foo');
+$test2 = $bag->get('foo', null);
+$test3 = $bag->get('foo', '');
+$test4 = $bag->get('foo', 'baz');
+
+die;

--- a/tests/Type/Symfony/input_bag_get.php
+++ b/tests/Type/Symfony/input_bag_get.php
@@ -6,8 +6,5 @@ $test1 = $bag->get('foo');
 $test2 = $bag->get('foo', null);
 $test3 = $bag->get('foo', '');
 $test4 = $bag->get('foo', 'baz');
-$test5 = $bag->get('foo', 16);
-$test6 = $bag->get('foo', true);
-$test7 = $bag->get('foo', []);
 
 die;

--- a/tests/Type/Symfony/input_bag_get.php
+++ b/tests/Type/Symfony/input_bag_get.php
@@ -6,5 +6,8 @@ $test1 = $bag->get('foo');
 $test2 = $bag->get('foo', null);
 $test3 = $bag->get('foo', '');
 $test4 = $bag->get('foo', 'baz');
+$test5 = $bag->get('foo', 16);
+$test6 = $bag->get('foo', true);
+$test7 = $bag->get('foo', []);
 
 die;


### PR DESCRIPTION
For the InputBag::get, if you add a default string parameter, it will always return a string. This is new in Symfony 5.0.

Fixes issue #91 