### PR TITLE
Adjusts getOption return type if no default value.

### DIFF
--- a/src/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtension.php
@@ -67,12 +67,12 @@ final class InputInterfaceGetOptionDynamicReturnTypeExtension implements Dynamic
 				if (!$option->acceptValue()) {
 					$optType = new BooleanType();
 				} else {
-					$optType = TypeCombinator::union(new StringType(), new IntegerType(), new NullType());
+					$optType = TypeCombinator::union(new StringType(), new NullType());
 					if ($option->isValueRequired() && ($option->isArray() || $option->getDefault() !== null)) {
 						$optType = TypeCombinator::removeNull($optType);
 					}
 					if ($option->isArray()) {
-						$optType = new ArrayType(new IntegerType(), TypeCombinator::remove($optType, new IntegerType()));
+						$optType = new ArrayType(new IntegerType(), $optType);
 					}
 					$optType = TypeCombinator::union($optType, $scope->getTypeFromValue($option->getDefault()));
 				}

--- a/tests/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtensionTest.php
@@ -27,8 +27,8 @@ final class InputInterfaceGetOptionDynamicReturnTypeExtensionTest extends Extens
 	public function argumentTypesProvider(): Iterator
 	{
 		yield ['$a', 'bool'];
-		yield ['$b', 'int|string|null'];
-		yield ['$c', 'int|string|null'];
+		yield ['$b', 'string|null'];
+		yield ['$c', 'string|null'];
 		yield ['$d', 'array<int, string|null>'];
 		yield ['$e', 'array<int, string>'];
 


### PR DESCRIPTION
I read discussion in #45 about adding `int` type for `getOption`. But reading Symfony source code and doing some tests, `int` type is only possible if an `int` default value has been passed to `addOption`.