### PR TITLE
Bump minimum versions to prevent deprecations while running in lowest mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "consistence/coding-standard": "^3.10",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
     "ergebnis/composer-normalize": "^2.0.2",
-    "phing/phing": "^2.16.0",
+    "phing/phing": "^2.16.2",
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpstan/phpstan-phpunit": "^0.12.8",
     "phpstan/phpstan-strict-rules": "^0.12.2",


### PR DESCRIPTION
This removes the deprecations. These are confusing for contributors.