### PR TITLE
Add FormTypeExtensionInterface stub

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,7 @@ parameters:
 		- stubs/ExtensionInterface.stub
 		- stubs/FormBuilderInterface.stub
 		- stubs/FormInterface.stub
+		- stubs/FormTypeExtensionInterface.stub
 		- stubs/FormTypeInterface.stub
 		- stubs/FormView.stub
 		- stubs/HeaderBag.stub

--- a/stubs/FormTypeExtensionInterface.stub
+++ b/stubs/FormTypeExtensionInterface.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+interface FormTypeExtensionInterface
+{
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options): void;
+
+    /**
+     * @param array<mixed> $options
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options): void;
+}

--- a/stubs/FormTypeExtensionInterface.stub
+++ b/stubs/FormTypeExtensionInterface.stub
@@ -5,17 +5,17 @@ namespace Symfony\Component\Form;
 interface FormTypeExtensionInterface
 {
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void;
 
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void;
 
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function finishView(FormView $view, FormInterface $form, array $options): void;
 }

--- a/stubs/FormTypeInterface.stub
+++ b/stubs/FormTypeInterface.stub
@@ -5,17 +5,17 @@ namespace Symfony\Component\Form;
 interface FormTypeInterface
 {
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void;
 
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void;
 
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      */
     public function finishView(FormView $view, FormInterface $form, array $options): void;
 }


### PR DESCRIPTION
Since it implements nearly the same interface, but isn't typehinted either ($options missing iterable type)

How can I test that?