### PR TITLE
Add stubs for Twig Node and Symfony ParameterBag

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -24,8 +24,10 @@ parameters:
 		- stubs/FormTypeInterface.stub
 		- stubs/FormView.stub
 		- stubs/HeaderBag.stub
+		- stubs/Node.stub
 		- stubs/NormalizableInterface.stub
 		- stubs/NormalizerInterface.stub
+		- stubs/ParameterBag.stub
 		- stubs/Process.stub
 		- stubs/Session.stub
 

--- a/stubs/Node.stub
+++ b/stubs/Node.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Twig\Node;
+
+/**
+ * @implements \IteratorAggregate<string, self>
+ */
+class Node implements \IteratorAggregate
+{
+
+}

--- a/stubs/ParameterBag.stub
+++ b/stubs/ParameterBag.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * @implements \IteratorAggregate<string, mixed>
+ */
+class ParameterBag implements \IteratorAggregate
+{
+
+}


### PR DESCRIPTION
Repeat of #80 with already existing stubs removed.

These solve errors like:

```
Method AppBundle\Templating\Twig\TokenParser\MyNode::
parse() return type has no value type specified in iterable type Twig\Node\Node.
💡 Consider adding something like Twig\Node\Node<Foo> to the PHPDoc.
```

or

```
Method AppBundle\Controller\Test::validateRequestData()
has parameter $data with no value type specified in iterable type Symfony\Component\HttpFoundation\ParameterBag.
💡 Consider adding something like Symfony\Component\HttpFoundation\ParameterBag<Foo> to the PHPDoc.
```