### PR TITLE
Support for TreeBuilder::getRootNode()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     "phpstan/phpstan-strict-rules": "^0.12.5",
     "phpunit/phpunit": "^7.5.20",
     "symfony/console": "^4.0",
+    "symfony/config": "^4.2",
     "symfony/framework-bundle": "^4.0",
     "symfony/http-foundation": "^4.0",
     "symfony/messenger": "^4.2",

--- a/extension.neon
+++ b/extension.neon
@@ -145,3 +145,13 @@ services:
 	-
 		factory: PHPStan\Type\Symfony\InputInterfaceHasOptionDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+	# new TreeBuilder() return type
+	-
+		factory: PHPStan\Type\Symfony\TreeBuilderDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicStaticMethodReturnTypeExtension]
+
+	# TreeBuilder::getRootNode() return type
+	-
+		factory: PHPStan\Type\Symfony\TreeBuilderGetRootNodeDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/Symfony/TreeBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/TreeBuilderDynamicReturnTypeExtension.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PHPStan\Analyser\Scope;
+use PHPStan\Broker\Broker;
+use PHPStan\Reflection\BrokerAwareExtension;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\ConstantScalarType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class TreeBuilderDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension, BrokerAwareExtension
+{
+
+	/** @var Broker */
+	private $broker;
+
+	public function setBroker(Broker $broker): void
+	{
+		$this->broker = $broker;
+	}
+
+	public function getClass(): string
+	{
+		return 'Symfony\Component\Config\Definition\Builder\TreeBuilder';
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === '__construct';
+	}
+
+	public function getTypeFromStaticMethodCall(MethodReflection $methodReflection, StaticCall $methodCall, Scope $scope): Type
+	{
+		if (!$methodCall->class instanceof Name) {
+			throw new \PHPStan\ShouldNotHappenException();
+		}
+
+		$className = $scope->resolveName($methodCall->class);
+		if (!$this->broker->hasClass($className)) {
+			return ParametersAcceptorSelector::selectSingle(
+				$methodReflection->getVariants()
+			)->getReturnType();
+		}
+
+		$args = [];
+		foreach ($methodCall->args as $arg) {
+			$value = $scope->getType($arg->value);
+
+			if (!$value instanceof ConstantScalarType) {
+				throw new \LogicException();
+			}
+
+			$args[] = $value->getValue();
+		}
+
+		$treeBuilder = new $className(
+			...$args
+		);
+
+		return new TreeBuilderType($className, $treeBuilder->getRootNode());
+	}
+
+}

--- a/src/Type/Symfony/TreeBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/TreeBuilderDynamicReturnTypeExtension.php
@@ -9,25 +9,18 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\EnumNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\FloatNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition;
 
 final class TreeBuilderDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
 {
 
 	private const MAPPING = [
-		'variable' => VariableNodeDefinition::class,
-		'scalar' => ScalarNodeDefinition::class,
-		'boolean' => BooleanNodeDefinition::class,
-		'integer' => IntegerNodeDefinition::class,
-		'float' => FloatNodeDefinition::class,
-		'array' => ArrayNodeDefinition::class,
-		'enum' => EnumNodeDefinition::class,
+		'variable' => 'Symfony\Component\Config\Definition\Builder\VariableNodeDefinition',
+		'scalar' => 'Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition',
+		'boolean' => 'Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition',
+		'integer' => 'Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition',
+		'float' => 'Symfony\Component\Config\Definition\Builder\FloatNodeDefinition',
+		'array' => 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition',
+		'enum' => 'Symfony\Component\Config\Definition\Builder\EnumNodeDefinition',
 	];
 
 	public function getClass(): string

--- a/src/Type/Symfony/TreeBuilderGetRootNodeDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/TreeBuilderGetRootNodeDynamicReturnTypeExtension.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Type;
+
+final class TreeBuilderGetRootNodeDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Symfony\Component\Config\Definition\Builder\TreeBuilder';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getRootNode';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$calledOnType = $scope->getType($methodCall->var);
+		if ($calledOnType instanceof TreeBuilderType) {
+			$nodeDefinition = $calledOnType->getNodeDefinition();
+
+			return new \PHPStan\Type\ObjectType(get_class($nodeDefinition));
+		}
+
+		return new \PHPStan\Type\ObjectType('Symfony\Component\Config\Definition\Builder\NodeDefinition');
+	}
+
+}

--- a/src/Type/Symfony/TreeBuilderGetRootNodeDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/TreeBuilderGetRootNodeDynamicReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 final class TreeBuilderGetRootNodeDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
@@ -29,12 +30,10 @@ final class TreeBuilderGetRootNodeDynamicReturnTypeExtension implements DynamicM
 	{
 		$calledOnType = $scope->getType($methodCall->var);
 		if ($calledOnType instanceof TreeBuilderType) {
-			$nodeDefinition = $calledOnType->getNodeDefinition();
-
-			return new \PHPStan\Type\ObjectType(get_class($nodeDefinition));
+			return new ObjectType($calledOnType->getRootNodeClassName());
 		}
 
-		return new \PHPStan\Type\ObjectType('Symfony\Component\Config\Definition\Builder\NodeDefinition');
+		return $methodReflection->getVariants()[0]->getReturnType();
 	}
 
 }

--- a/src/Type/Symfony/TreeBuilderType.php
+++ b/src/Type/Symfony/TreeBuilderType.php
@@ -3,24 +3,23 @@
 namespace PHPStan\Type\Symfony;
 
 use PHPStan\Type\ObjectType;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 class TreeBuilderType extends ObjectType
 {
 
-	/** @var NodeDefinition */
-	private $nodeDefinition;
+	/** @var string */
+	private $rootNodeClassName;
 
-	public function __construct(string $className, NodeDefinition $nodeDefinition)
+	public function __construct(string $className, string $rootNodeClassName)
 	{
 		parent::__construct($className);
 
-		$this->nodeDefinition = $nodeDefinition;
+		$this->rootNodeClassName = $rootNodeClassName;
 	}
 
-	public function getNodeDefinition(): NodeDefinition
+	public function getRootNodeClassName(): string
 	{
-		return $this->nodeDefinition;
+		return $this->rootNodeClassName;
 	}
 
 }

--- a/src/Type/Symfony/TreeBuilderType.php
+++ b/src/Type/Symfony/TreeBuilderType.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PHPStan\Type\ObjectType;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+class TreeBuilderType extends ObjectType
+{
+
+	/** @var NodeDefinition */
+	private $nodeDefinition;
+
+	public function __construct(string $className, NodeDefinition $nodeDefinition)
+	{
+		parent::__construct($className);
+
+		$this->nodeDefinition = $nodeDefinition;
+	}
+
+	public function getNodeDefinition(): NodeDefinition
+	{
+		return $this->nodeDefinition;
+	}
+
+}

--- a/tests/Type/Symfony/EnvelopeReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/EnvelopeReturnTypeExtensionTest.php
@@ -18,7 +18,7 @@ final class EnvelopeReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/envelope_all.php',
 			$expression,
 			$type,
-			new EnvelopeReturnTypeExtension()
+			[new EnvelopeReturnTypeExtension()]
 		);
 	}
 

--- a/tests/Type/Symfony/ExtensionTestCase.php
+++ b/tests/Type/Symfony/ExtensionTestCase.php
@@ -17,21 +17,28 @@ use PHPStan\PhpDoc\PhpDocNodeResolver;
 use PHPStan\PhpDoc\PhpDocStringResolver;
 use PHPStan\Reflection\ReflectionProvider\DirectReflectionProviderProvider;
 use PHPStan\Testing\TestCase;
-use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\VerbosityLevel;
 
 abstract class ExtensionTestCase extends TestCase
 {
 
+	/**
+	 * @param string $file
+	 * @param string $expression
+	 * @param string $type
+	 * @param \PHPStan\Type\DynamicMethodReturnTypeExtension[] $dynamicMethodReturnTypeExtensions
+	 * @param \PHPStan\Type\DynamicStaticMethodReturnTypeExtension[] $dynamicStaticMethodReturnTypeExtensions
+	 */
 	protected function processFile(
 		string $file,
 		string $expression,
 		string $type,
-		DynamicMethodReturnTypeExtension $extension
+		array $dynamicMethodReturnTypeExtensions = [],
+		array $dynamicStaticMethodReturnTypeExtensions = []
 	): void
 	{
-		$broker = $this->createBroker([$extension]);
+		$broker = $this->createBroker($dynamicMethodReturnTypeExtensions, $dynamicStaticMethodReturnTypeExtensions);
 		$parser = $this->getParser();
 		$currentWorkingDirectory = $this->getCurrentWorkingDirectory();
 		$fileHelper = new FileHelper($currentWorkingDirectory);

--- a/tests/Type/Symfony/HeaderBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/HeaderBagDynamicReturnTypeExtensionTest.php
@@ -16,7 +16,7 @@ final class HeaderBagDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/header_bag_get.php',
 			$expression,
 			$type,
-			new HeaderBagDynamicReturnTypeExtension()
+			[new HeaderBagDynamicReturnTypeExtension()]
 		);
 	}
 

--- a/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputBagDynamicReturnTypeExtensionTest.php
@@ -20,7 +20,7 @@ final class InputBagDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/input_bag_get.php',
 			$expression,
 			$type,
-			new InputBagDynamicReturnTypeExtension()
+			[new InputBagDynamicReturnTypeExtension()]
 		);
 	}
 

--- a/tests/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtensionTest.php
@@ -17,7 +17,7 @@ final class InputInterfaceGetArgumentDynamicReturnTypeExtensionTest extends Exte
 			__DIR__ . '/ExampleBaseCommand.php',
 			$expression,
 			$type,
-			new InputInterfaceGetArgumentDynamicReturnTypeExtension(new ConsoleApplicationResolver(__DiR__ . '/console_application_loader.php'))
+			[new InputInterfaceGetArgumentDynamicReturnTypeExtension(new ConsoleApplicationResolver(__DiR__ . '/console_application_loader.php'))]
 		);
 	}
 

--- a/tests/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/InputInterfaceGetOptionDynamicReturnTypeExtensionTest.php
@@ -17,7 +17,7 @@ final class InputInterfaceGetOptionDynamicReturnTypeExtensionTest extends Extens
 			__DIR__ . '/ExampleOptionCommand.php',
 			$expression,
 			$type,
-			new InputInterfaceGetOptionDynamicReturnTypeExtension(new ConsoleApplicationResolver(__DiR__ . '/console_application_loader.php'))
+			[new InputInterfaceGetOptionDynamicReturnTypeExtension(new ConsoleApplicationResolver(__DiR__ . '/console_application_loader.php'))]
 		);
 	}
 

--- a/tests/Type/Symfony/KernelInterfaceDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/KernelInterfaceDynamicReturnTypeExtensionTest.php
@@ -16,7 +16,7 @@ final class KernelInterfaceDynamicReturnTypeExtensionTest extends ExtensionTestC
 			__DIR__ . '/kernel_interface.php',
 			$expression,
 			$type,
-			new KernelInterfaceDynamicReturnTypeExtension()
+			[new KernelInterfaceDynamicReturnTypeExtension()]
 		);
 	}
 

--- a/tests/Type/Symfony/RequestDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/RequestDynamicReturnTypeExtensionTest.php
@@ -16,7 +16,7 @@ final class RequestDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/request_get_content.php',
 			$expression,
 			$type,
-			new RequestDynamicReturnTypeExtension()
+			[new RequestDynamicReturnTypeExtension()]
 		);
 	}
 

--- a/tests/Type/Symfony/SerializerDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/SerializerDynamicReturnTypeExtensionTest.php
@@ -16,10 +16,10 @@ final class SerializerDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/serializer.php',
 			$expression,
 			$type,
-			new SerializerDynamicReturnTypeExtension(
+			[new SerializerDynamicReturnTypeExtension(
 				'Symfony\Component\Serializer\SerializerInterface',
 				'deserialize'
-			)
+			)]
 		);
 	}
 
@@ -32,10 +32,10 @@ final class SerializerDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/denormalizer.php',
 			$expression,
 			$type,
-			new SerializerDynamicReturnTypeExtension(
+			[new SerializerDynamicReturnTypeExtension(
 				'Symfony\Component\Serializer\Normalizer\DenormalizerInterface',
 				'denormalize'
-			)
+			)]
 		);
 	}
 

--- a/tests/Type/Symfony/ServiceDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/ServiceDynamicReturnTypeExtensionTest.php
@@ -18,7 +18,7 @@ final class ServiceDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/ExampleController.php',
 			$expression,
 			$type,
-			new ServiceDynamicReturnTypeExtension(Controller::class, true, (new XmlServiceMapFactory($container))->create())
+			[new ServiceDynamicReturnTypeExtension(Controller::class, true, (new XmlServiceMapFactory($container))->create())]
 		);
 	}
 
@@ -55,7 +55,7 @@ final class ServiceDynamicReturnTypeExtensionTest extends ExtensionTestCase
 			__DIR__ . '/ExampleController.php',
 			$expression,
 			$type,
-			new ServiceDynamicReturnTypeExtension(Controller::class, false, (new XmlServiceMapFactory($container))->create())
+			[new ServiceDynamicReturnTypeExtension(Controller::class, false, (new XmlServiceMapFactory($container))->create())]
 		);
 	}
 

--- a/tests/Type/Symfony/TreeBuilderDynamicReturnTypeExtensionTest.php
+++ b/tests/Type/Symfony/TreeBuilderDynamicReturnTypeExtensionTest.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use Iterator;
+
+final class TreeBuilderDynamicReturnTypeExtensionTest extends ExtensionTestCase
+{
+
+	/**
+	 * @dataProvider getProvider
+	 */
+	public function testGet(string $expression, string $type): void
+	{
+		$this->processFile(
+			__DIR__ . '/tree_builder.php',
+			$expression,
+			$type,
+			[new TreeBuilderGetRootNodeDynamicReturnTypeExtension()],
+			[new TreeBuilderDynamicReturnTypeExtension()]
+		);
+	}
+
+	/**
+	 * @return \Iterator<array{string, string}>
+	 */
+	public function getProvider(): Iterator
+	{
+		yield ['$treeRootNode', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
+		yield ['$variableRootNode', 'Symfony\Component\Config\Definition\Builder\VariableNodeDefinition'];
+		yield ['$scalarRootNode', 'Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition'];
+		yield ['$booleanRootNode', 'Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition'];
+		yield ['$integerRootNode', 'Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition'];
+		yield ['$floatRootNode', 'Symfony\Component\Config\Definition\Builder\FloatNodeDefinition'];
+		yield ['$arrayRootNode', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
+		yield ['$enumRootNode', 'Symfony\Component\Config\Definition\Builder\EnumNodeDefinition'];
+	}
+
+}

--- a/tests/Type/Symfony/tree_builder.php
+++ b/tests/Type/Symfony/tree_builder.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+$treeBuilder = new TreeBuilder('my_tree');
+$treeRootNode = $treeBuilder->getRootNode();
+
+$variableTreeBuilder = new TreeBuilder('my_tree', 'variable');
+$variableRootNode = $variableTreeBuilder->getRootNode();
+
+$scalarTreeBuilder = new TreeBuilder('my_tree', 'scalar');
+$scalarRootNode = $scalarTreeBuilder->getRootNode();
+
+$booleanTreeBuilder = new TreeBuilder('my_tree', 'boolean');
+$booleanRootNode = $booleanTreeBuilder->getRootNode();
+
+$integerTreeBuilder = new TreeBuilder('my_tree', 'integer');
+$integerRootNode = $integerTreeBuilder->getRootNode();
+
+$floatTreeBuilder = new TreeBuilder('my_tree', 'float');
+$floatRootNode = $floatTreeBuilder->getRootNode();
+
+$arrayTreeBuilder = new TreeBuilder('my_tree', 'array');
+$arrayRootNode = $arrayTreeBuilder->getRootNode();
+
+$enumTreeBuilder = new TreeBuilder('my_tree', 'enum');
+$enumRootNode = $enumTreeBuilder->getRootNode();
+
+die;


### PR DESCRIPTION
After seeing #60 stuck I decided to give it a shot... 

This is very naive, and it assumes the `TreeBuilder` is always of type `array`.

```
TreeBuilder::__construct(string $name, string $type = 'array', NodeBuilder $builder = null)
```

If I am able to find the second `$type` parameter to the `new TreeBuilder()` call then I can make the return type of `getRootNode` dynamic based on that.

@ondrejmirtes Is this even possible?

The issue with NodeDefinition::end() is that it can return `null` when you've reached the root. The current extension removes the nullability in favor of DX. But it's also very naive. No idea if that can be done dynamically.

Hope to get some advice on how to proceed.... 🙏 