### PR TITLE
Fix phpstan callback type problem

### DIFF
--- a/stubs/ChoiceLoaderInterface.stub
+++ b/stubs/ChoiceLoaderInterface.stub
@@ -6,7 +6,7 @@ interface ChoiceLoaderInterface
 {
     /**
      * @param array<string> $values
-     * @param callable|null $value
+     * @param callable(mixed): void|null $value
      *
      * @return array<mixed>
      */
@@ -14,7 +14,7 @@ interface ChoiceLoaderInterface
 
     /**
      * @param array<mixed> $choices
-     * @param callable|null $value
+     * @param callable(mixed): void|null $value
      *
      * @return array<string>
      */


### PR DESCRIPTION
phpstan throw error for this stub
`vendor/phpstan/phpstan-symfony/stubs/ChoiceLoaderInterface.stub`

```
-
    message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Loader\\\\ChoiceLoaderInterface\\:\\:loadChoicesForValues\\(\\) has parameter \\$value with no signature specified for callable\\.$#"
    count: 1
    path: vendor/phpstan/phpstan-symfony/stubs/ChoiceLoaderInterface.stub

-
    message: "#^Method Symfony\\\\Component\\\\Form\\\\ChoiceList\\\\Loader\\\\ChoiceLoaderInterface\\:\\:loadValuesForChoices\\(\\) has parameter \\$value with no signature specified for callable\\.$#"
    count: 1
    path: vendor/phpstan/phpstan-symfony/stubs/ChoiceLoaderInterface.stub
```

I updated annotation to fix this error for phpstan

related docs
https://phpstan.org/user-guide/stub-files

the above document said:
```
What about the analysis of the stub files?

Stub files don’t need to be added to the list of analysed paths. They’re analysed independently of the chosen rule level with a set of select rules mainly evaluating the PHPDoc well-formedness.

Errors reported in the stub files also can’t be ignored and all of them must be fixed.
```
