### PR TITLE
Fix beforeNormalization

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -182,7 +182,7 @@ services:
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 		arguments:
 		    className: Symfony\Component\Config\Definition\Builder\NodeDefinition
-		    methods: [children, validate]
+		    methods: [children, validate, beforeNormalization]
 
 	# NodeDefinition::end() return type
 	-

--- a/tests/Type/Symfony/Config/TreeBuilderTest.php
+++ b/tests/Type/Symfony/Config/TreeBuilderTest.php
@@ -4,7 +4,6 @@ namespace PHPStan\Type\Symfony\Config;
 
 use Iterator;
 use PHPStan\Type\Symfony\ExtensionTestCase;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 final class TreeBuilderTest extends ExtensionTestCase
 {

--- a/tests/Type/Symfony/Config/TreeBuilderTest.php
+++ b/tests/Type/Symfony/Config/TreeBuilderTest.php
@@ -138,50 +138,50 @@ final class TreeBuilderTest extends ExtensionTestCase
 		yield ['
 		$arrayRootNode
 			->children()
-                ->arrayNode("methods")
-                    ->prototype("scalar")
-                        ->defaultNull()
-                    ->end()
-                ->end()
-            ->end()
+				->arrayNode("methods")
+					->prototype("scalar")
+						->defaultNull()
+					->end()
+				->end()
+			->end()
 		', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
 		yield ['
 		$arrayRootNode
 			->children()
-                ->arrayNode("methods")
-                    ->scalarPrototype()
-                        ->defaultNull()
-                    ->end()
-                ->end()
-            ->end()
+				->arrayNode("methods")
+					->scalarPrototype()
+						->defaultNull()
+					->end()
+				->end()
+			->end()
 		', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
 		yield ['
 		$arrayRootNode
 			->children()
-                ->arrayNode("methods")
-                    ->prototype("scalar")
-                        ->validate()
-                            ->ifNotInArray(["one", "two"])
-                            ->thenInvalid("%s is not a valid method.")
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
+				->arrayNode("methods")
+					->prototype("scalar")
+						->validate()
+							->ifNotInArray(["one", "two"])
+							->thenInvalid("%s is not a valid method.")
+						->end()
+					->end()
+				->end()
+			->end()
 		', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
 		yield ['
 		$arrayRootNode
 			->children()
-                ->arrayNode("methods")
-                    ->prototype("array")
-                        ->beforeNormalization()
-                            ->ifString()
-                            ->then(static function ($v) {
+				->arrayNode("methods")
+					->prototype("array")
+						->beforeNormalization()
+							->ifString()
+							->then(static function ($v) {
 								return [$v];
 							})
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
+						->end()
+					->end()
+				->end()
+			->end()
 		', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
 
 		yield ['$variableRootNode', 'Symfony\Component\Config\Definition\Builder\VariableNodeDefinition'];

--- a/tests/Type/Symfony/Config/TreeBuilderTest.php
+++ b/tests/Type/Symfony/Config/TreeBuilderTest.php
@@ -24,7 +24,7 @@ final class TreeBuilderTest extends ExtensionTestCase
 				new ReturnParentDynamicReturnTypeExtension('Symfony\Component\Config\Definition\Builder\NodeBuilder', ['end']),
 				new ReturnParentDynamicReturnTypeExtension('Symfony\Component\Config\Definition\Builder\NodeDefinition', ['end']),
 				new PassParentObjectDynamicReturnTypeExtension('Symfony\Component\Config\Definition\Builder\NodeBuilder', ['arrayNode', 'scalarNode', 'booleanNode', 'integerNode', 'floatNode', 'enumNode', 'variableNode']),
-				new PassParentObjectDynamicReturnTypeExtension('Symfony\Component\Config\Definition\Builder\NodeDefinition', ['children', 'validate']),
+				new PassParentObjectDynamicReturnTypeExtension('Symfony\Component\Config\Definition\Builder\NodeDefinition', ['children', 'validate', 'beforeNormalization']),
 				new TreeBuilderGetRootNodeDynamicReturnTypeExtension(),
 			],
 			[new TreeBuilderDynamicReturnTypeExtension()]
@@ -164,6 +164,21 @@ final class TreeBuilderTest extends ExtensionTestCase
                         ->validate()
                             ->ifNotInArray(["one", "two"])
                             ->thenInvalid("%s is not a valid method.")
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+		', 'Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition'];
+		yield ['
+		$arrayRootNode
+			->children()
+                ->arrayNode("methods")
+                    ->prototype("array")
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(static function ($v) {
+								return [$v];
+							})
                         ->end()
                     ->end()
                 ->end()

--- a/tests/Type/Symfony/Config/TreeBuilderTest.php
+++ b/tests/Type/Symfony/Config/TreeBuilderTest.php
@@ -14,20 +14,6 @@ final class TreeBuilderTest extends ExtensionTestCase
 	 */
 	public function testGet(string $expression, string $type): void
 	{
-		$arrayTreeBuilder = new TreeBuilder('my_tree', 'array');
-		$arrayRootNode = $arrayTreeBuilder->getRootNode();
-		$r = $arrayRootNode
-			->children()
-			->arrayNode('methods')
-			->prototype('scalar')
-			->validate()
-			->ifNotInArray(['one', 'two'])
-			->thenInvalid('%s is not a valid method.')
-			->end()
-			->end()
-			->end()
-			->end();
-
 		$this->processFile(
 			__DIR__ . '/tree_builder.php',
 			$expression,


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan-symfony/pull/131 cc @ruudk 

BeforeNormalization has the same behavior than validate.

This fix an issue with 
```
->children()
    ->arrayNode('information')
        ->useAttributeAsKey('id')
        ->prototype('array')
            ->beforeNormalization()
                ->ifString()
                ->then(static function ($v) {
                    return [$v];
                })
            ->end()
            ->prototype('scalar')->end()
        ->end(
```
```
Call to an undefined method Symfony\Component\Config\Definition\Builder\NodeDefinition::prototype().
```

I tried it on my project and it fix the error. A release after the merge could be great if you have time @ondrejmirtes :) 