### PR TITLE
Support for ServiceLocator

### DIFF
--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -54,7 +54,8 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		$isTestContainerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Test\TestContainer'))->isSuperTypeOf($argType);
 		$isOldServiceSubscriber = (new ObjectType('Symfony\Component\DependencyInjection\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
 		$isServiceSubscriber = (new ObjectType('Symfony\Contracts\Service\ServiceSubscriberInterface'))->isSuperTypeOf($argType);
-		if ($isTestContainerType->yes() || $isOldServiceSubscriber->yes() || $isServiceSubscriber->yes()) {
+		$isServiceLocator = (new ObjectType('Symfony\Component\DependencyInjection\ServiceLocator'))->isSuperTypeOf($argType);
+		if ($isTestContainerType->yes() || $isOldServiceSubscriber->yes() || $isServiceSubscriber->yes() || $isServiceLocator->yes()) {
 			return [];
 		}
 

--- a/tests/Rules/Symfony/ExampleController.php
+++ b/tests/Rules/Symfony/ExampleController.php
@@ -39,4 +39,9 @@ final class ExampleController extends Controller
 		$this->get('unknown');
 	}
 
+	public function privateServiceFromServiceLocator(): void
+	{
+		$this->get('service_locator')->get('private');
+	}
+
 }

--- a/tests/Rules/Symfony/container.xml
+++ b/tests/Rules/Symfony/container.xml
@@ -3,5 +3,10 @@
     <services>
         <service id="private" class="Foo" public="false"></service>
         <service id="public" class="Foo"></service>
+        <service id="service_locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
+            <argument type="collection">
+                <argument key="private" type="service" id="private"/>
+            </argument>
+        </service>
     </services>
 </container>


### PR DESCRIPTION
Now when private services are fetching from Psr\Container\ContainerInterface::get(), an error "Service "%s" is private" occurred.

But Symfony has [ServiceLocators](https://symfony.com/doc/current/service_container/service_subscribers_locators.html#defining-a-service-locator) in order to define smaller containers with public access to services.

This PR solves error "Service "%s" is private" when service is fetching from ServiceLocator.