### PR TITLE
Fix synthetic return type when class is available

### DIFF
--- a/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
@@ -68,7 +68,7 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->args[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
-			if ($service !== null && !$service->isSynthetic()) {
+			if ($service !== null && (!$service->isSynthetic() || $service->getClass() !== null)) {
 				return new ObjectType($service->getClass() ?? $serviceId);
 			}
 		}

--- a/tests/Type/Symfony/container.xml
+++ b/tests/Type/Symfony/container.xml
@@ -34,5 +34,6 @@
 
     <services>
         <service id="foo" class="Foo"></service>
+        <service id="synthetic" class="Synthetic" synthetic="true" />
     </services>
 </container>

--- a/tests/Type/Symfony/data/ExampleAbstractController.php
+++ b/tests/Type/Symfony/data/ExampleAbstractController.php
@@ -13,11 +13,13 @@ final class ExampleAbstractController extends AbstractController
 	public function services(): void
 	{
 		assertType('Foo', $this->get('foo'));
+		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));
 		assertType('object', $this->get());
 
 		assertType('true', $this->has('foo'));
+		assertType('true', $this->has('synthetic'));
 		assertType('false', $this->has('bar'));
 		assertType('bool', $this->has(doFoo()));
 		assertType('bool', $this->has());

--- a/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
@@ -12,11 +12,13 @@ final class ExampleAbstractControllerWithoutContainer extends AbstractController
 	public function services(): void
 	{
 		assertType('object', $this->get('foo'));
+		assertType('object', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));
 		assertType('object', $this->get());
 
 		assertType('bool', $this->has('foo'));
+		assertType('bool', $this->has('synthetic'));
 		assertType('bool', $this->has('bar'));
 		assertType('bool', $this->has(doFoo()));
 		assertType('bool', $this->has());

--- a/tests/Type/Symfony/data/ExampleController.php
+++ b/tests/Type/Symfony/data/ExampleController.php
@@ -13,11 +13,13 @@ final class ExampleController extends Controller
 	public function services(): void
 	{
 		assertType('Foo', $this->get('foo'));
+		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));
 		assertType('object', $this->get());
 
 		assertType('true', $this->has('foo'));
+		assertType('true', $this->has('synthetic'));
 		assertType('false', $this->has('bar'));
 		assertType('bool', $this->has(doFoo()));
 		assertType('bool', $this->has());

--- a/tests/Type/Symfony/data/ExampleControllerWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleControllerWithoutContainer.php
@@ -12,11 +12,13 @@ final class ExampleControllerWithoutContainer extends Controller
 	public function services(): void
 	{
 		assertType('object', $this->get('foo'));
+		assertType('object', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));
 		assertType('object', $this->get());
 
 		assertType('bool', $this->has('foo'));
+		assertType('bool', $this->has('synthetic'));
 		assertType('bool', $this->has('bar'));
 		assertType('bool', $this->has(doFoo()));
 		assertType('bool', $this->has());


### PR DESCRIPTION
When a synthetic service has a class. We should use that for the type.

All tests are red on my Machine, so I didn't write a test 😓 
Issue: #154