### PR TITLE
Add default phpunit testsuite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,5 +61,8 @@
     ]
   },
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "scripts": {
+    "test": "phpunit -c tests"
+  }
 }

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -15,6 +15,11 @@
             <directory suffix=".php">../src</directory>
         </whitelist>
     </filter>
+    <testsuites>
+        <testsuite name="PHPStan Symfony Integration">
+        <directory>.</directory>
+        </testsuite>
+  </testsuites>
     <logging>
         <log
                 type="coverage-text"


### PR DESCRIPTION
No need to give the folder always in the Command

Still works: `./vendor/bin/phpunit -c tests tests`
Now works also `./vendor/bin/phpunit -c tests`
or better `composer test`