### PR TITLE
chore: Use the latest PHPUnit wherever possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,10 +38,9 @@ jobs:
       - name: "Install dependencies"
         run: "composer install --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
-
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "Lint"
         run: "make lint"
@@ -111,9 +110,9 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "Tests"
         run: "make tests"
@@ -155,9 +154,9 @@ jobs:
         if: ${{ matrix.dependencies == 'highest' }}
         run: "composer update --no-interaction --no-progress --no-suggest"
 
-      - name: "Update PHPUnit"
-        if: matrix.php-version == '7.4' || matrix.php-version == '8.0'
-        run: "composer require --dev phpunit/phpunit:'^9.5' --update-with-dependencies"
+      - name: "Downgrade PHPUnit"
+        if: matrix.php-version == '7.1' || matrix.php-version == '7.2' || matrix.php-version == '7.3'
+        run: "composer require --dev phpunit/phpunit:^7.5.20 --update-with-dependencies"
 
       - name: "PHPStan"
         run: "make phpstan"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpstan/phpstan-phpunit": "^0.12.16",
     "phpstan/phpstan-strict-rules": "^0.12.5",
-    "phpunit/phpunit": "^7.5.20",
+    "phpunit/phpunit": "^9.5",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/console": "^4.0 || ^5.0",
     "symfony/framework-bundle": "^4.4 || ^5.0",


### PR DESCRIPTION
Related to https://github.com/phpstan/phpstan-mockery/pull/30#issuecomment-841182105

---

- [ ] https://github.com/phpstan/phpstan-doctrine - see https://github.com/phpstan/phpstan-doctrine/pull/186
- [ ] https://github.com/phpstan/phpstan-beberlei-assert - see https://github.com/phpstan/phpstan-beberlei-assert/pull/23
- [ ] https://github.com/phpstan/phpstan-strict-rules - see https://github.com/phpstan/phpstan-strict-rules/pull/126
- [ ] https://github.com/phpstan/phpstan-webmozart-assert - see https://github.com/phpstan/phpstan-webmozart-assert/pull/48
- [ ] https://github.com/phpstan/phpstan-php-parser - see https://github.com/phpstan/phpstan-php-parser/pull/10
- [ ] https://github.com/phpstan/phpstan-mockery - see 
- [ ] https://github.com/phpstan/extension-installer - see https://github.com/phpstan/extension-installer/pull/33
- [ ] https://github.com/phpstan/phpstan-dibi - see https://github.com/phpstan/phpstan-dibi/pull/12
- [ ] https://github.com/phpstan/phpstan-nette - see 
- [ ] https://github.com/phpstan/phpstan-phpunit - see 
- [ ] https://github.com/phpstan/phpstan-deprecation-rules - see 
- [ ] https://github.com/phpstan/phpdoc-parser - see 
