### PR TITLE
Dynamically load XML container via PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,32 @@ parameters:
         container_xml_path: var/cache/dev/App_KernelDevDebugContainer.xml
 ```
 
+The XML file should exist prior to running PHPStan.
+
+If you want this file to be created automatically and resolved based on `APP_ENV` you can use this:
+
+```yaml
+parameters:
+    symfony:
+        container_xml_path: tests/container-loader.php
+```
+
+```php
+//tests/container-loader.php
+
+use App\Kernel;
+use Symfony\Component\Dotenv\Dotenv;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+(new Dotenv())->bootEnv(__DIR__ . '/../.env');
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool) $_SERVER['APP_DEBUG']);
+$kernel->boot();
+
+return file_get_contents($kernel->getContainer()->getParameter('debug.container.dump'));
+```
+
 ## Constant hassers
 
 Sometimes, when you are dealing with optional dependencies, the `::has()` methods can cause problems. For example, the following construct would complain that the condition is always either on or off, depending on whether you have the dependency for `service` installed:

--- a/extension.neon
+++ b/extension.neon
@@ -59,17 +59,23 @@ services:
 		arguments:
 		    consoleApplicationLoader: %symfony.console_application_loader%
 
+	# xml container resolver
+	-
+		factory: PHPStan\Symfony\XmlContainerResolver
+		arguments:
+		    containerXmlPath: %symfony.container_xml_path%
+
 	# service map
 	symfony.serviceMapFactory:
 		class: PHPStan\Symfony\ServiceMapFactory
-		factory: PHPStan\Symfony\XmlServiceMapFactory(%symfony.container_xml_path%)
+		factory: PHPStan\Symfony\XmlServiceMapFactory
 	-
 		factory: @symfony.serviceMapFactory::create()
 
 	# parameter map
 	symfony.parameterMapFactory:
 		class: PHPStan\Symfony\ParameterMapFactory
-		factory: PHPStan\Symfony\XmlParameterMapFactory(%symfony.container_xml_path%)
+		factory: PHPStan\Symfony\XmlParameterMapFactory
 	-
 		factory: @symfony.parameterMapFactory::create()
 

--- a/src/Symfony/XmlContainerResolver.php
+++ b/src/Symfony/XmlContainerResolver.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PHPStan\ShouldNotHappenException;
+use SimpleXMLElement;
+
+final class XmlContainerResolver
+{
+
+	/** @var string|null */
+	private $containerXmlPath;
+
+	/** @var SimpleXMLElement|null */
+	private $container;
+
+	public function __construct(?string $containerXmlPath)
+	{
+		$this->containerXmlPath = $containerXmlPath;
+	}
+
+	public function getContainer(): ?SimpleXMLElement
+	{
+		if ($this->containerXmlPath === null) {
+			return null;
+		}
+
+		if ($this->container !== null) {
+			return $this->container;
+		}
+
+		if (pathinfo($this->containerXmlPath, PATHINFO_EXTENSION) === 'php') {
+			$fileContents = require $this->containerXmlPath;
+
+			if (!is_string($fileContents)) {
+				throw new ShouldNotHappenException();
+			}
+		} else {
+			$fileContents = file_get_contents($this->containerXmlPath);
+			if ($fileContents === false) {
+				throw new XmlContainerNotExistsException(sprintf('Container %s does not exist', $this->containerXmlPath));
+			}
+		}
+
+		$container = @simplexml_load_string($fileContents);
+		if ($container === false) {
+			throw new XmlContainerNotExistsException(sprintf('Container %s cannot be parsed', $this->containerXmlPath));
+		}
+
+		$this->container = $container;
+
+		return $this->container;
+	}
+
+}

--- a/src/Symfony/XmlParameterMapFactory.php
+++ b/src/Symfony/XmlParameterMapFactory.php
@@ -7,33 +7,25 @@ use function sprintf;
 final class XmlParameterMapFactory implements ParameterMapFactory
 {
 
-	/** @var string|null */
-	private $containerXml;
+	/** @var XmlContainerResolver */
+	private $containerResolver;
 
-	public function __construct(?string $containerXml)
+	public function __construct(XmlContainerResolver $containerResolver)
 	{
-		$this->containerXml = $containerXml;
+		$this->containerResolver = $containerResolver;
 	}
 
 	public function create(): ParameterMap
 	{
-		if ($this->containerXml === null) {
+		$container = $this->containerResolver->getContainer();
+
+		if ($container === null) {
 			return new FakeParameterMap();
-		}
-
-		$fileContents = file_get_contents($this->containerXml);
-		if ($fileContents === false) {
-			throw new XmlContainerNotExistsException(sprintf('Container %s does not exist', $this->containerXml));
-		}
-
-		$xml = @simplexml_load_string($fileContents);
-		if ($xml === false) {
-			throw new XmlContainerNotExistsException(sprintf('Container %s cannot be parsed', $this->containerXml));
 		}
 
 		/** @var \PHPStan\Symfony\Parameter[] $parameters */
 		$parameters = [];
-		foreach ($xml->parameters->parameter as $def) {
+		foreach ($container->parameters->parameter as $def) {
 			/** @var \SimpleXMLElement $attrs */
 			$attrs = $def->attributes();
 

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServicePhpLoaderRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServicePhpLoaderRuleTest.php
@@ -10,12 +10,12 @@ use PHPStan\Testing\RuleTestCase;
 /**
  * @extends RuleTestCase<ContainerInterfacePrivateServiceRule>
  */
-final class ContainerInterfacePrivateServiceRuleTest extends RuleTestCase
+final class ContainerInterfacePrivateServicePhpLoaderRuleTest extends RuleTestCase
 {
 
 	protected function getRule(): Rule
 	{
-		return new ContainerInterfacePrivateServiceRule((new XmlServiceMapFactory(new XmlContainerResolver(__DIR__ . '/container.xml')))->create());
+		return new ContainerInterfacePrivateServiceRule((new XmlServiceMapFactory(new XmlContainerResolver(__DIR__ . '/container_loader.php')))->create());
 	}
 
 	public function testGetPrivateService(): void

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleFakeTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleFakeTest.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Rules\Symfony;
 
 use PHPStan\Rules\Rule;
+use PHPStan\Symfony\XmlContainerResolver;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 
@@ -14,7 +15,7 @@ final class ContainerInterfacePrivateServiceRuleFakeTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ContainerInterfacePrivateServiceRule((new XmlServiceMapFactory(null))->create());
+		return new ContainerInterfacePrivateServiceRule((new XmlServiceMapFactory(new XmlContainerResolver(null)))->create());
 	}
 
 	public function testGetPrivateService(): void

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleFakeTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleFakeTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Symfony;
 
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Rules\Rule;
+use PHPStan\Symfony\XmlContainerResolver;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\Symfony\ServiceTypeSpecifyingExtension;
@@ -16,7 +17,7 @@ final class ContainerInterfaceUnknownServiceRuleFakeTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ContainerInterfaceUnknownServiceRule((new XmlServiceMapFactory(null))->create(), new Standard());
+		return new ContainerInterfaceUnknownServiceRule((new XmlServiceMapFactory(new XmlContainerResolver(null)))->create(), new Standard());
 	}
 
 	/**

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Symfony;
 
 use PhpParser\PrettyPrinter\Standard;
 use PHPStan\Rules\Rule;
+use PHPStan\Symfony\XmlContainerResolver;
 use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use PHPStan\Type\Symfony\ServiceTypeSpecifyingExtension;
@@ -17,7 +18,7 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 
 	protected function getRule(): Rule
 	{
-		return new ContainerInterfaceUnknownServiceRule((new XmlServiceMapFactory(__DIR__ . '/container.xml'))->create(), new Standard());
+		return new ContainerInterfaceUnknownServiceRule((new XmlServiceMapFactory(new XmlContainerResolver(__DIR__ . '/container.xml')))->create(), new Standard());
 	}
 
 	/**

--- a/tests/Rules/Symfony/container_loader.php
+++ b/tests/Rules/Symfony/container_loader.php
@@ -1,0 +1,3 @@
+<?php declare(strict_types = 1);
+
+return file_get_contents(__DIR__ . '/container.xml');

--- a/tests/Symfony/DefaultParameterMapTest.php
+++ b/tests/Symfony/DefaultParameterMapTest.php
@@ -13,13 +13,13 @@ final class DefaultParameterMapTest extends TestCase
 	 */
 	public function testGetParameter(string $key, callable $validator): void
 	{
-		$factory = new XmlParameterMapFactory(__DIR__ . '/container.xml');
+		$factory = new XmlParameterMapFactory(new XmlContainerResolver(__DIR__ . '/container.xml'));
 		$validator($factory->create()->getParameter($key));
 	}
 
 	public function testGetParameterEscapedPath(): void
 	{
-		$factory = new XmlParameterMapFactory(__DIR__ . '/containers/bugfix%2Fcontainer.xml');
+		$factory = new XmlParameterMapFactory(new XmlContainerResolver(__DIR__ . '/containers/bugfix%2Fcontainer.xml'));
 		$serviceMap = $factory->create();
 
 		self::assertNotNull($serviceMap->getParameter('app.string'));

--- a/tests/Symfony/DefaultServiceMapTest.php
+++ b/tests/Symfony/DefaultServiceMapTest.php
@@ -13,13 +13,13 @@ final class DefaultServiceMapTest extends TestCase
 	 */
 	public function testGetService(string $id, callable $validator): void
 	{
-		$factory = new XmlServiceMapFactory(__DIR__ . '/container.xml');
+		$factory = new XmlServiceMapFactory(new XmlContainerResolver(__DIR__ . '/container.xml'));
 		$validator($factory->create()->getService($id));
 	}
 
 	public function testGetContainerEscapedPath(): void
 	{
-		$factory = new XmlServiceMapFactory(__DIR__ . '/containers/bugfix%2Fcontainer.xml');
+		$factory = new XmlServiceMapFactory(new XmlContainerResolver(__DIR__ . '/containers/bugfix%2Fcontainer.xml'));
 		$serviceMap = $factory->create();
 
 		self::assertNotNull($serviceMap->getService('withClass'));


### PR DESCRIPTION
This allows to automatically resolve the XML container configuration based on environment variables.

It also has the benefit that it will automatically create the XML container file when it's not present (as it boots the container once).

Fixes https://github.com/phpstan/phpstan-symfony/issues/105