### PR TITLE
Fix DenormalizableInterface::denormalize() return type declaration

### DIFF
--- a/stubs/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.stub
@@ -9,8 +9,6 @@ interface DenormalizableInterface
      * @param array<mixed>|string|int|float|bool $data
      * @param string|null $format
      * @param array<mixed> $context
-     *
-     * @return object|object[]
      */
     public function denormalize($denormalizer, $data, $format = null, array $context = []);
 }

--- a/stubs/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.stub
@@ -9,6 +9,8 @@ interface DenormalizableInterface
      * @param array<mixed>|string|int|float|bool $data
      * @param string|null $format
      * @param array<mixed> $context
+     *
+     * @return void
      */
     public function denormalize($denormalizer, $data, $format = null, array $context = []);
 }


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/39561

DenormalizableInterface::denormalize() should not return anything, so the `@return` declaration should be removed. If you look at the usage in `CustomNormalizer::denormalize()`, it becomes clear that this method shouldn't return anything:
```php
    public function denormalize($data, $type, $format = null, array $context = [])
    {
        $object = $this->extractObjectToPopulate($type, $context) ?: new $type();
        $object->denormalize($this->serializer, $data, $format, $context);

        return $object;
    }
```

Note that in this case `$object implements DenormalizableInterface`, so this is about the `$object->normalize()` call above.