### PR TITLE
Add back AclInterface stub

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -26,6 +26,8 @@ parameters:
 		- stubs/Symfony/Component/HttpFoundation/Session.stub
 		- stubs/Symfony/Component/Process/Process.stub
 		- stubs/Symfony/Component/PropertyAccess/PropertyPathInterface.stub
+		- stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub
+		- stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub

--- a/stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub
+++ b/stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub
@@ -1,0 +1,40 @@
+<?php
+
+namespace Symfony\Component\Security\Acl\Model;
+
+interface AclInterface
+{
+
+    /**
+     * Returns all class-based ACEs associated with this ACL.
+     *
+     * @return array<int, EntryInterface>
+     */
+    public function getClassAces();
+
+    /**
+     * Returns all class-field-based ACEs associated with this ACL.
+     *
+     * @param string $field
+     *
+     * @return array<int, EntryInterface>
+     */
+    public function getClassFieldAces($field);
+
+    /**
+     * Returns all object-based ACEs associated with this ACL.
+     *
+     * @return array<int, EntryInterface>
+     */
+    public function getObjectAces();
+
+    /**
+     * Returns all object-field-based ACEs associated with this ACL.
+     *
+     * @param string $field
+     *
+     * @return array<int, EntryInterface>
+     */
+    public function getObjectFieldAces($field);
+
+}

--- a/stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub
+++ b/stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Security\Acl\Model;
+
+interface EntryInterface
+{
+}


### PR DESCRIPTION
HI @ondrejmirtes, the security stubs were fixing two things:
- The `AclProviderInterface`/`MutableAclProviderInterface` issue. This will be fixed in Symfony 5.4 and wasn't easily fixed in phpstan.
- The array keys of the `AclInterface` methods wich is int (and not string|int). I opened a PR on Symfony, but having the stub here allow to fix the issue for all the version of symfony (even < 5.4). For instance the sonata build is currently failing because of the removal of this stub.

So I think we should add it back.