### PR TITLE
Add Constraint::$errorNames

### DIFF
--- a/stubs/Symfony/Component/Validator/Constraint.stub
+++ b/stubs/Symfony/Component/Validator/Constraint.stub
@@ -5,6 +5,11 @@ namespace Symfony\Component\Validator;
 class Constraint
 {
     /**
+     * @var array<string, string>
+     */
+    protected static $errorNames = [];
+
+    /**
      * @return array<mixed>
      */
     public function getRequiredOptions();


### PR DESCRIPTION
Getting this error on a custom constraint. Adding the type in the stub fixes it.

```
Library/Symfony/Constraint/BankAccount.php:26
 ↳ Type array<string, string> of property App\Library\Symfony\Constraint\BankAccount::$errorNames is not the same as type mixed of overridden property Symfony\Component\Validator\Constraint::$errorNames.
```