### PR TITLE
XmlServiceMapFactory: Add more info in case of XML can not be parsed.

### DIFF
--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -31,7 +31,7 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 
 		$xml = @simplexml_load_string($fileContents);
 		if ($xml === false) {
-			throw new XmlContainerNotExistsException(sprintf('Container %s cannot be parsed', $this->containerXml));
+			throw new XmlContainerNotExistsException(sprintf('Container %s cannot be parsed: %s', $this->containerXml, error_get_last()['message'] ?? 'XML parser error'));
 		}
 
 		/** @var \PHPStan\Symfony\Service[] $services */


### PR DESCRIPTION
The current error message only informs that a parsing error has occurred. More information should be added to the message as to why the parsing failed.

Current error message:

<img width="921" alt="Snímek obrazovky 2021-11-24 v 14 17 31" src="https://user-images.githubusercontent.com/4738758/143245635-b2607215-42c4-4766-9561-433d430da589.png">

