### PR TITLE
Fix false positive "Service ... is private." when using KernelTestCase::$container

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -9,6 +9,8 @@ parameters:
 		constant_hassers: true
 		console_application_loader: null
 	stubFiles:
+		- stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
+		- stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
 		- stubs/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.stub
 		- stubs/Symfony/Component/DependencyInjection/ContainerBuilder.stub
 		- stubs/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.stub

--- a/stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+abstract class KernelTestCase
+{
+    /**
+     * @var TestContainer
+     */
+    protected static $container;
+}

--- a/stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Test;
+
+class TestContainer
+{
+}


### PR DESCRIPTION
This fixes the false positive reported in #27.

This makes sure that when you call `self::$container->get(...)` in a `KernelTestCase`, you don't get the 'Service ... is private.' error.