### PR TITLE
Services are private by default

### DIFF
--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -48,7 +48,7 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 			$service = new Service(
 				strpos((string) $attrs->id, '.') === 0 ? substr((string) $attrs->id, 1) : (string) $attrs->id,
 				isset($attrs->class) ? (string) $attrs->class : null,
-				!isset($attrs->public) || (string) $attrs->public !== 'false',
+				isset($attrs->public) && (string) $attrs->public === 'true',
 				isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
 				isset($attrs->alias) ? (string) $attrs->alias : null
 			);

--- a/tests/Symfony/DefaultServiceMapTest.php
+++ b/tests/Symfony/DefaultServiceMapTest.php
@@ -42,7 +42,7 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertNotNull($service);
 				self::assertSame('withoutClass', $service->getId());
 				self::assertNull($service->getClass());
-				self::assertTrue($service->isPublic());
+				self::assertFalse($service->isPublic());
 				self::assertFalse($service->isSynthetic());
 				self::assertNull($service->getAlias());
 			},
@@ -53,7 +53,7 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertNotNull($service);
 				self::assertSame('withClass', $service->getId());
 				self::assertSame('Foo', $service->getClass());
-				self::assertTrue($service->isPublic());
+				self::assertFalse($service->isPublic());
 				self::assertFalse($service->isSynthetic());
 				self::assertNull($service->getAlias());
 			},
@@ -64,29 +64,29 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertNotNull($service);
 				self::assertSame('withoutPublic', $service->getId());
 				self::assertSame('Foo', $service->getClass());
-				self::assertTrue($service->isPublic());
+				self::assertFalse($service->isPublic());
 				self::assertFalse($service->isSynthetic());
 				self::assertNull($service->getAlias());
 			},
 		];
 		yield [
-			'publicNotFalse',
+			'publicNotTrue',
 			function (?Service $service): void {
 				self::assertNotNull($service);
-				self::assertSame('publicNotFalse', $service->getId());
-				self::assertSame('Foo', $service->getClass());
-				self::assertTrue($service->isPublic());
-				self::assertFalse($service->isSynthetic());
-				self::assertNull($service->getAlias());
-			},
-		];
-		yield [
-			'private',
-			function (?Service $service): void {
-				self::assertNotNull($service);
-				self::assertSame('private', $service->getId());
+				self::assertSame('publicNotTrue', $service->getId());
 				self::assertSame('Foo', $service->getClass());
 				self::assertFalse($service->isPublic());
+				self::assertFalse($service->isSynthetic());
+				self::assertNull($service->getAlias());
+			},
+		];
+		yield [
+			'public',
+			function (?Service $service): void {
+				self::assertNotNull($service);
+				self::assertSame('public', $service->getId());
+				self::assertSame('Foo', $service->getClass());
+				self::assertTrue($service->isPublic());
 				self::assertFalse($service->isSynthetic());
 				self::assertNull($service->getAlias());
 			},
@@ -97,7 +97,7 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertNotNull($service);
 				self::assertSame('synthetic', $service->getId());
 				self::assertSame('Foo', $service->getClass());
-				self::assertTrue($service->isPublic());
+				self::assertFalse($service->isPublic());
 				self::assertTrue($service->isSynthetic());
 				self::assertNull($service->getAlias());
 			},
@@ -108,7 +108,7 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertNotNull($service);
 				self::assertSame('alias', $service->getId());
 				self::assertSame('Foo', $service->getClass());
-				self::assertTrue($service->isPublic());
+				self::assertFalse($service->isPublic());
 				self::assertFalse($service->isSynthetic());
 				self::assertSame('withClass', $service->getAlias());
 			},

--- a/tests/Symfony/container.xml
+++ b/tests/Symfony/container.xml
@@ -37,8 +37,8 @@
     <service id="withoutClass"></service>
     <service id="withClass" class="Foo"></service>
     <service id="withoutPublic" class="Foo"></service>
-    <service id="publicNotFalse" class="Foo" public="true"></service>
-    <service id="private" class="Foo" public="false"></service>
+    <service id="publicNotTrue" class="Foo" public="false"></service>
+    <service id="public" class="Foo" public="true"></service>
     <service id="synthetic" class="Foo" synthetic="true"></service>
     <service id="alias" class="Bar" alias="withClass"></service>
   </services>

--- a/tests/Type/Symfony/container.xml
+++ b/tests/Type/Symfony/container.xml
@@ -37,7 +37,7 @@
     </parameters>
 
     <services>
-        <service id="foo" class="Foo"></service>
-        <service id="synthetic" class="Synthetic" synthetic="true" />
+        <service id="foo" class="Foo" public="true"></service>
+        <service id="synthetic" class="Synthetic" public="true" synthetic="true" />
     </services>
 </container>


### PR DESCRIPTION
This fixes #75.

This changes marks services as private when they are not explicitly public.