### PR TITLE
Fix FormView stub

### DIFF
--- a/stubs/Symfony/Component/Form/FormView.stub
+++ b/stubs/Symfony/Component/Form/FormView.stub
@@ -6,8 +6,8 @@ use ArrayAccess;
 use IteratorAggregate;
 
 /**
- * @implements IteratorAggregate<string, self>
- * @implements ArrayAccess<string, self>
+ * @implements IteratorAggregate<int|string, self>
+ * @implements ArrayAccess<int|string, self>
  */
 class FormView implements ArrayAccess, IteratorAggregate
 {
@@ -15,7 +15,7 @@ class FormView implements ArrayAccess, IteratorAggregate
     /**
      * Returns an iterator to iterate over children (implements \IteratorAggregate).
      *
-     * @return \ArrayIterator<string, FormView> The iterator
+     * @return \ArrayIterator<int|string, FormView> The iterator
      */
     public function getIterator();
 


### PR DESCRIPTION
Hi @ondrejmirtes, since https://github.com/symfony/symfony/pull/44764/files the FormView phpstan-stub is wrong.

This create an issue because when using both phpstan and psalm, the first one require string as key when the second use the symfony definition and allow both int and string.