### PR TITLE
Introduce DynamicReturnTypeExtension for 'Symfony\Component\Form\FormInterface::getErrors'

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "phpunit/phpunit": "^9.5",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/console": "^4.0 || ^5.0",
+    "symfony/form": "^4.0 || ^5.0",
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/http-foundation": "^4.0 || ^5.0",
     "symfony/messenger": "^4.2 || ^5.0",

--- a/extension.neon
+++ b/extension.neon
@@ -249,3 +249,8 @@ services:
 		class: PHPStan\Symfony\InputBagStubFilesExtension
 		tags:
 			- phpstan.stubFilesExtension
+
+	# FormInterface::getErrors() return type
+	-
+		factory: PHPStan\Type\Symfony\Form\FormInterfaceDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/Symfony/Form/FormInterfaceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/Form/FormInterfaceDynamicReturnTypeExtension.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony\Form;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantBooleanType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormInterface;
+
+final class FormInterfaceDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return FormInterface::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getErrors';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		if (!isset($methodCall->getArgs()[1])) {
+			return new GenericObjectType(FormErrorIterator::class, [new ObjectType(FormError::class)]);
+		}
+
+		$firstArgType = $scope->getType($methodCall->getArgs()[0]->value);
+		$secondArgType = $scope->getType($methodCall->getArgs()[1]->value);
+
+		$firstIsTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($firstArgType);
+		$firstIsFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($firstArgType);
+		$secondIsTrueType = (new ConstantBooleanType(true))->isSuperTypeOf($secondArgType);
+		$secondIsFalseType = (new ConstantBooleanType(false))->isSuperTypeOf($secondArgType);
+
+		$firstCompareType = $firstIsTrueType->compareTo($firstIsFalseType);
+		$secondCompareType = $secondIsTrueType->compareTo($secondIsFalseType);
+
+		if ($firstCompareType === $firstIsTrueType && $secondCompareType === $secondIsFalseType) {
+			return new GenericObjectType(FormErrorIterator::class, [
+				new UnionType([
+					new ObjectType(FormError::class),
+					new ObjectType(FormErrorIterator::class),
+				]),
+			]);
+		}
+
+		return new GenericObjectType(FormErrorIterator::class, [new ObjectType(FormError::class)]);
+	}
+
+}

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -49,6 +49,8 @@ class ExtensionTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/denormalizer.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/FormInterface_getErrors.php');
 	}
 
 	/**

--- a/tests/Type/Symfony/data/FormInterface_getErrors.php
+++ b/tests/Type/Symfony/data/FormInterface_getErrors.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormInterface;
+use function PHPStan\Testing\assertType;
+
+/** @var FormInterface $form */
+$form = new stdClass();
+
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors());
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors(false));
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors(false, true));
+
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors(true));
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors(true, true));
+
+assertType(FormErrorIterator::class . '<'. FormError::class .'>', $form->getErrors(false, false));
+
+assertType(FormErrorIterator::class . '<'. FormError::class .'|'. FormErrorIterator::class . '>', $form->getErrors(true, false));


### PR DESCRIPTION
Hey there :wave: 

this is my attempt to fix https://github.com/phpstan/phpstan-symfony/issues/166

Hope I get everything right :see_no_evil: 
It took some time, but once I got how the test suite works, it was quite straight forward :+1: good job here!

Let me know, if something is missing :slightly_smiling_face: 