### PR TITLE
Request > Return `Session` instead of `SessionInterface`

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -118,6 +118,11 @@ services:
 		factory: PHPStan\Type\Symfony\RequestDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
+	# Request::getSession() return type
+	-
+		factory: PHPStan\Type\Symfony\RequestGetSessionReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
 	# Request::getSession() type specification
 	-
 		factory: PHPStan\Type\Symfony\RequestTypeSpecifyingExtension

--- a/src/Type/Symfony/RequestGetSessionReturnTypeExtension.php
+++ b/src/Type/Symfony/RequestGetSessionReturnTypeExtension.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+final class RequestGetSessionReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Symfony\Component\HttpFoundation\Request';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getSession';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		return new ObjectType('Symfony\Component\HttpFoundation\Session\Session');
+	}
+
+}

--- a/tests/Type/Symfony/data/request_get_session.php
+++ b/tests/Type/Symfony/data/request_get_session.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types = 1);
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use function PHPStan\Testing\assertType;
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
 $request = doRequest();
 
 $session1 = $request->getSession();
-assertType(SessionInterface::class, $request->getSession());
+assertType(Session::class, $request->getSession());
 
 if ($request->hasSession()) {
-	assertType(SessionInterface::class, $request->getSession());
+	assertType(Session::class, $request->getSession());
 }

--- a/tests/Type/Symfony/data/request_get_session_null.php
+++ b/tests/Type/Symfony/data/request_get_session_null.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types = 1);
 
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\HttpFoundation\Session\Session;
 use function PHPStan\Testing\assertType;
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
 $request = doRequest();
 
 $session1 = $request->getSession();
-assertType(SessionInterface::class . '|null', $request->getSession());
+assertType(Session::class . '|null', $request->getSession());
 
 if ($request->hasSession()) {
-	assertType(SessionInterface::class, $request->getSession());
+	assertType(Session::class, $request->getSession());
 }


### PR DESCRIPTION
Symfony 6 removed the `Session` and `FlashBagInterface` services.

That means that the only way to get the FlashBag (to add flashes) it to use `$request->getSession()->getFlashBag()`.

But the problem is, `getFlashBag` is not defined on the `SessionInterface`:
```
Call to an undefined method Symfony\Component\HttpFoundation\Session\SessionInterface::getFlashBag().
```

To make everyone's life easier, let's change the return type to `Sesssion` instead.
This is what's returned in a default Symfony application.