### PR TITLE
Post request variables can be only string

### DIFF
--- a/stubs/Symfony/Component/HttpFoundation/Request.stub
+++ b/stubs/Symfony/Component/HttpFoundation/Request.stub
@@ -8,7 +8,7 @@ class Request
 	/**
 	 * Request body parameters ($_POST).
 	 *
-	 * @var InputBag<string|int|float|bool>
+	 * @var InputBag<string>
 	 */
 	public $request;
 

--- a/tests/Type/Symfony/data/input_bag_from_request.php
+++ b/tests/Type/Symfony/data/input_bag_from_request.php
@@ -10,11 +10,11 @@ class Foo
 
 	public function doFoo(Request $request): void
 	{
-		assertType('bool|float|int|string|null', $request->request->get('foo'));
+		assertType('string|null', $request->request->get('foo'));
 		assertType('string|null', $request->query->get('foo'));
 		assertType('string|null', $request->cookies->get('foo'));
 
-		assertType('bool|float|int|string', $request->request->get('foo', 'foo'));
+		assertType('string', $request->request->get('foo', 'foo'));
 		assertType('string', $request->query->get('foo', 'foo'));
 		assertType('string', $request->cookies->get('foo', 'foo'));
 	}


### PR DESCRIPTION
Just like query variables the request variables can be only string. Even you sends `1` as post variable, you gets string.

@ondrejmirtes Why was it originally done differently?