### PR TITLE
Add analysis for route generation by controllers and UrlGeneratorInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension provides following features:
 * Provides correct return types for `TreeBuilder` and `NodeDefinition` objects.
 * Notifies you when you try to get an unregistered service from the container.
 * Notifies you when you try to get a private service from the container.
+* Notifies you when you try to generate a URL for a non-existing route name.
 * Optionally correct return types for `InputInterface::getArgument()`, `::getOption`, `::hasArgument`, and `::hasOption`.
 
 
@@ -147,4 +148,14 @@ Call the new env in your `console-application.php`:
 
 ```php
 $kernel = new \App\Kernel('phpstan_env', (bool) $_SERVER['APP_DEBUG']);
+```
+
+# Analysis of generating URLs
+
+You have to provide a path to `url_generating_routes.php` for the url generating analysis to work.
+
+```yaml
+parameters:
+    symfony:
+      urlGeneratingRulesFile: var/cache/dev/url_generating_routes.xml
 ```

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "symfony/http-foundation": "^5.1",
     "symfony/messenger": "^4.2 || ^5.0",
     "symfony/polyfill-php80": "^1.24",
+    "symfony/routing": "^4.4 || ^5.0",
     "symfony/serializer": "^4.0 || ^5.0"
   },
   "config": {

--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,8 @@ parameters:
 		constantHassers: true
 		console_application_loader: null
 		consoleApplicationLoader: null
+		url_generating_rules_file: null
+		urlGeneratingRulesFile: null
 	stubFiles:
 		- stubs/Psr/Cache/CacheItemInterface.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/KernelBrowser.stub
@@ -65,6 +67,8 @@ parametersSchema:
 		constantHassers: bool()
 		console_application_loader: schema(string(), nullable())
 		consoleApplicationLoader: schema(string(), nullable())
+		url_generating_rules_file: schema(string(), nullable())
+		urlGeneratingRulesFile: schema(string(), nullable())
 	])
 
 services:
@@ -88,6 +92,13 @@ services:
 		factory: PHPStan\Symfony\XmlParameterMapFactory
 	-
 		factory: @symfony.parameterMapFactory::create()
+
+	# url generating routes map
+	symfony.urlGeneratingRoutesMapFactory:
+		class: PHPStan\Symfony\UrlGeneratingRoutesMapFactory
+		factory: PHPStan\Symfony\PhpUrlGeneratingRoutesMapFactory
+	-
+		factory: @symfony.urlGeneratingRoutesMapFactory::create()
 
 	# ControllerTrait::get()/has() return type
 	-

--- a/rules.neon
+++ b/rules.neon
@@ -5,4 +5,5 @@ rules:
 	- PHPStan\Rules\Symfony\InvalidArgumentDefaultValueRule
 	- PHPStan\Rules\Symfony\UndefinedOptionRule
 	- PHPStan\Rules\Symfony\InvalidOptionDefaultValueRule
+	- PHPStan\Rules\Symfony\UrlGeneratorInterfaceUnknownRouteRule
 

--- a/src/Rules/Symfony/UrlGeneratorInterfaceUnknownRouteRule.php
+++ b/src/Rules/Symfony/UrlGeneratorInterfaceUnknownRouteRule.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Symfony\UrlGeneratingRoutesMap;
+use PHPStan\Type\ObjectType;
+
+/**
+ * @implements Rule<MethodCall>
+ */
+final class UrlGeneratorInterfaceUnknownRouteRule implements Rule
+{
+
+	/** @var UrlGeneratingRoutesMap */
+	private $urlGeneratingRoutesMap;
+
+	public function __construct(UrlGeneratingRoutesMap $urlGeneratingRoutesMap)
+	{
+		$this->urlGeneratingRoutesMap = $urlGeneratingRoutesMap;
+	}
+
+	public function getNodeType(): string
+	{
+		return MethodCall::class;
+	}
+
+	/**
+	 * @param \PhpParser\Node $node
+	 * @param \PHPStan\Analyser\Scope $scope
+	 * @return (string|\PHPStan\Rules\RuleError)[] errors
+	 */
+	public function processNode(Node $node, Scope $scope): array
+	{
+		if (!$node instanceof MethodCall) {
+			throw new ShouldNotHappenException();
+		}
+
+		if (!$node->name instanceof Node\Identifier) {
+			return [];
+		}
+
+		if (in_array($node->name->name, ['generate', 'generateUrl'], true) === false || !isset($node->getArgs()[0])) {
+			return [];
+		}
+
+		$argType = $scope->getType($node->var);
+		$isControllerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\Controller'))->isSuperTypeOf($argType);
+		$isAbstractControllerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\AbstractController'))->isSuperTypeOf($argType);
+		$isUrlGeneratorInterface = (new ObjectType('Symfony\Component\Routing\Generator\UrlGeneratorInterface'))->isSuperTypeOf($argType);
+		if (
+			$isControllerType->no()
+			&& $isAbstractControllerType->no()
+			&& $isUrlGeneratorInterface->no()
+		) {
+			return [];
+		}
+
+		$routeName = $this->urlGeneratingRoutesMap::getRouteNameFromNode($node->getArgs()[0]->value, $scope);
+		if ($routeName === null) {
+			return [];
+		}
+
+		if ($this->urlGeneratingRoutesMap->hasRouteName($routeName) === false) {
+			return [sprintf('Route with name "%s" does not exist.', $routeName)];
+		}
+
+		return [];
+	}
+
+}

--- a/src/Symfony/Configuration.php
+++ b/src/Symfony/Configuration.php
@@ -31,4 +31,9 @@ final class Configuration
 		return $this->parameters['consoleApplicationLoader'] ?? $this->parameters['console_application_loader'] ?? null;
 	}
 
+	public function getUrlGeneratingRoutesFile(): ?string
+	{
+		return $this->parameters['urlGeneratingRulesFile'] ?? $this->parameters['url_generating_rules_file'] ?? null;
+	}
+
 }

--- a/src/Symfony/DefaultUrlGeneratingRoutesMap.php
+++ b/src/Symfony/DefaultUrlGeneratingRoutesMap.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\TypeUtils;
+use function count;
+
+final class DefaultUrlGeneratingRoutesMap implements UrlGeneratingRoutesMap
+{
+
+	/** @var \PHPStan\Symfony\UrlGeneratingRoutesDefinition[] */
+	private $routes;
+
+	/**
+	 * @param \PHPStan\Symfony\UrlGeneratingRoutesDefinition[] $routes
+	 */
+	public function __construct(array $routes)
+	{
+		$this->routes = $routes;
+	}
+
+	public function hasRouteName(string $name): bool
+	{
+		foreach ($this->routes as $route) {
+			if ($route->getName() === $name) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	public static function getRouteNameFromNode(Expr $node, Scope $scope): ?string
+	{
+		$strings = TypeUtils::getConstantStrings($scope->getType($node));
+		return count($strings) === 1 ? $strings[0]->getValue() : null;
+	}
+
+}

--- a/src/Symfony/FakeUrlGeneratingRoutesMap.php
+++ b/src/Symfony/FakeUrlGeneratingRoutesMap.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+
+final class FakeUrlGeneratingRoutesMap implements UrlGeneratingRoutesMap
+{
+
+	public function hasRouteName(string $name): bool
+	{
+		return false;
+	}
+
+	public static function getRouteNameFromNode(Expr $node, Scope $scope): ?string
+	{
+		return null;
+	}
+
+}

--- a/src/Symfony/PhpUrlGeneratingRoutesMapFactory.php
+++ b/src/Symfony/PhpUrlGeneratingRoutesMapFactory.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use function sprintf;
+
+final class PhpUrlGeneratingRoutesMapFactory implements UrlGeneratingRoutesMapFactory
+{
+
+	/** @var string|null */
+	private $urlGeneratingRoutesFile;
+
+	public function __construct(Configuration $configuration)
+	{
+		$this->urlGeneratingRoutesFile = $configuration->getUrlGeneratingRoutesFile();
+	}
+
+	public function create(): UrlGeneratingRoutesMap
+	{
+		if ($this->urlGeneratingRoutesFile === null) {
+			return new FakeUrlGeneratingRoutesMap();
+		}
+
+		if (file_exists($this->urlGeneratingRoutesFile) === false) {
+			throw new UrlGeneratingRoutesFileNotExistsException(sprintf('File %s containing route generator information does not exist.', $this->urlGeneratingRoutesFile));
+		}
+
+		$urlGeneratingRoutes = require $this->urlGeneratingRoutesFile;
+
+		if (!is_array($urlGeneratingRoutes)) {
+			throw new UrlGeneratingRoutesFileNotExistsException(sprintf('File %s containing route generator information cannot be parsed.', $this->urlGeneratingRoutesFile));
+		}
+
+		/** @var \PHPStan\Symfony\UrlGeneratingRoutesDefinition[] $routes */
+		$routes = [];
+		foreach ($urlGeneratingRoutes as $routeName => $routeConfiguration) {
+			if (!is_string($routeName)) {
+				continue;
+			}
+
+			if (!is_array($routeConfiguration) || !isset($routeConfiguration[1]['_controller'])) {
+				continue;
+			}
+
+			$routes[] = new UrlGeneratingRoute($routeName, $routeConfiguration[1]['_controller']);
+		}
+
+		return new DefaultUrlGeneratingRoutesMap($routes);
+	}
+
+}

--- a/src/Symfony/UrlGeneratingRoute.php
+++ b/src/Symfony/UrlGeneratingRoute.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+class UrlGeneratingRoute implements UrlGeneratingRoutesDefinition
+{
+
+	/** @var string */
+	private $name;
+
+	/** @var string */
+	private $controller;
+
+	public function __construct(
+		string $name,
+		string $controller
+	)
+	{
+		$this->name = $name;
+		$this->controller = $controller;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	public function getController(): ?string
+	{
+		return $this->controller;
+	}
+
+}

--- a/src/Symfony/UrlGeneratingRoutesDefinition.php
+++ b/src/Symfony/UrlGeneratingRoutesDefinition.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+interface UrlGeneratingRoutesDefinition
+{
+
+	public function getName(): string;
+
+	public function getController(): ?string;
+
+}

--- a/src/Symfony/UrlGeneratingRoutesFileNotExistsException.php
+++ b/src/Symfony/UrlGeneratingRoutesFileNotExistsException.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+final class UrlGeneratingRoutesFileNotExistsException extends \InvalidArgumentException
+{
+
+}

--- a/src/Symfony/UrlGeneratingRoutesMap.php
+++ b/src/Symfony/UrlGeneratingRoutesMap.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+
+interface UrlGeneratingRoutesMap
+{
+
+	public function hasRouteName(string $name): bool;
+
+	public static function getRouteNameFromNode(Expr $node, Scope $scope): ?string;
+
+}

--- a/src/Symfony/UrlGeneratingRoutesMapFactory.php
+++ b/src/Symfony/UrlGeneratingRoutesMapFactory.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+interface UrlGeneratingRoutesMapFactory
+{
+
+	public function create(): UrlGeneratingRoutesMap;
+
+}

--- a/tests/Rules/Symfony/ExampleControllerWithRouting.php
+++ b/tests/Rules/Symfony/ExampleControllerWithRouting.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+final class ExampleControllerWithRouting extends AbstractController
+{
+
+	public function generateSomeRoute1(): void
+	{
+		$this->generateUrl('someRoute1');
+	}
+
+	public function generateNonExistingRoute(): void
+	{
+		$this->generateUrl('unknown');
+	}
+
+}

--- a/tests/Rules/Symfony/UrlGeneratorInterfaceUnknownRouteRuleTest.php
+++ b/tests/Rules/Symfony/UrlGeneratorInterfaceUnknownRouteRuleTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use PHPStan\Rules\Rule;
+use PHPStan\Symfony\Configuration;
+use PHPStan\Symfony\PhpUrlGeneratingRoutesMapFactory;
+use PHPStan\Testing\RuleTestCase;
+
+/**
+ * @extends RuleTestCase<UrlGeneratorInterfaceUnknownRouteRule>
+ */
+final class UrlGeneratorInterfaceUnknownRouteRuleTest extends RuleTestCase
+{
+
+	protected function getRule(): Rule
+	{
+		return new UrlGeneratorInterfaceUnknownRouteRule((new PhpUrlGeneratingRoutesMapFactory(new Configuration(['urlGeneratingRulesFile' => __DIR__ . '/url_generating_routes.php'])))->create());
+	}
+
+	public function testGenerate(): void
+	{
+		if (!class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
+			self::markTestSkipped();
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleControllerWithRouting.php',
+			],
+			[
+				[
+					'Route with name "unknown" does not exist.',
+					17,
+				],
+			]
+		);
+	}
+
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../../extension.neon',
+		];
+	}
+
+}

--- a/tests/Rules/Symfony/url_generating_routes.php
+++ b/tests/Rules/Symfony/url_generating_routes.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+return [
+	'someRoute1' => [[], ['_controller' => 'SomeController'] /* ... */],
+	'someRoute2' => [[], ['_controller' => 'SomeController'] /* ... */],
+	'someRoute3' => [[], ['_controller' => 'SomeController'] /* ... */],
+];

--- a/tests/Symfony/DefaultUrlGeneratingRoutesMapTest.php
+++ b/tests/Symfony/DefaultUrlGeneratingRoutesMapTest.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultUrlGeneratingRoutesMapTest extends TestCase
+{
+
+	/**
+	 * @dataProvider hasRouteNameProvider
+	 */
+	public function testHasRouteName(string $name, callable $validator): void
+	{
+		$factory = new PhpUrlGeneratingRoutesMapFactory(new Configuration(['urlGeneratingRulesFile' => __DIR__ . '/url_generating_routes.php']));
+		$validator($factory->create()->hasRouteName($name));
+	}
+
+	/**
+	 * @return \Iterator<mixed>
+	 */
+	public function hasRouteNameProvider(): Iterator
+	{
+		yield [
+			'unknown',
+			function (bool $hasRoute): void {
+				self::assertFalse($hasRoute);
+			},
+		];
+		yield [
+			'some.non.existing.route',
+			function (bool $hasRoute): void {
+				self::assertFalse($hasRoute);
+			},
+		];
+		yield [
+			'someRoute1',
+			function (bool $hasRoute): void {
+				self::assertTrue($hasRoute);
+			},
+		];
+		yield [
+			'someRoute2',
+			function (bool $hasRoute): void {
+				self::assertTrue($hasRoute);
+			},
+		];
+		yield [
+			'someRoute3',
+			function (bool $hasRoute): void {
+				self::assertTrue($hasRoute);
+			},
+		];
+	}
+
+}

--- a/tests/Symfony/url_generating_routes.php
+++ b/tests/Symfony/url_generating_routes.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types = 1);
+
+return [
+	'someRoute1' => [[], ['_controller' => 'SomeController'] /* ... */],
+	'someRoute2' => [[], ['_controller' => 'SomeController'] /* ... */],
+	'someRoute3' => [[], ['_controller' => 'SomeController'] /* ... */],
+];


### PR DESCRIPTION
Hi there.

we were in need of this feature to detect possible dead route generation when using dynamicly generated route "name"s through symfony by its `namespace_controller_method` style.

Therefore I've created this simple analysis which I would like to share with anyone in the same need.