### PR TITLE
Add missing save parameter to CacheInterface stub

### DIFF
--- a/stubs/Symfony/Contracts/Cache/CacheInterface.stub
+++ b/stubs/Symfony/Contracts/Cache/CacheInterface.stub
@@ -7,7 +7,7 @@ interface CacheInterface
     /**
      * @template T
      *
-     * @param \Symfony\Contracts\Cache\CallbackInterface<T>|callable(\Symfony\Contracts\Cache\ItemInterface): T $callback
+     * @param \Symfony\Contracts\Cache\CallbackInterface<T>|callable(\Symfony\Contracts\Cache\ItemInterface, bool): T $callback
      * @param array<mixed> $metadata
      * @return T
      */


### PR DESCRIPTION
The stub is missing the second save parameter on the callable that is defined in the [CallbackInterface](https://github.com/phpstan/phpstan-symfony/blob/96ee630098c49c1c25326ae51b027e469bfd2064/stubs/Symfony/Contracts/Cache/CallbackInterface.stub)