### PR TITLE
Add dynamic return type to ResponseHeaderBag::getCookies

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -273,3 +273,8 @@ services:
 	-
 		factory: PHPStan\Type\Symfony\CommandGetHelperDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+	# ResponseHeaderBag::getCookies() return type
+	-
+		factory: PHPStan\Type\Symfony\ResponseHeaderBagDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/Symfony/ResponseHeaderBagDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ResponseHeaderBagDynamicReturnTypeExtension.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeUtils;
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+final class ResponseHeaderBagDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return ResponseHeaderBag::class;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'getCookies';
+	}
+
+	public function getTypeFromMethodCall(
+		MethodReflection $methodReflection,
+		MethodCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		if (isset($methodCall->getArgs()[0])) {
+			$argStrings = TypeUtils::getConstantStrings($scope->getType($methodCall->getArgs()[0]->value));
+
+			if (count($argStrings) === 1 && $argStrings[0]->getValue() === ResponseHeaderBag::COOKIES_ARRAY) {
+				return new ArrayType(
+					new StringType(),
+					new ArrayType(
+						new StringType(),
+						new ArrayType(
+							new StringType(),
+							new ObjectType(Cookie::class)
+						)
+					)
+				);
+			}
+		}
+
+		return new ArrayType(new IntegerType(), new ObjectType(Cookie::class));
+	}
+
+}

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -14,6 +14,7 @@ class ExtensionTest extends TypeInferenceTestCase
 	{
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/envelope_all.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/header_bag_get.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/response_header_bag_get_cookies.php');
 
 		if (class_exists('Symfony\Component\HttpFoundation\InputBag')) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/input_bag.php');

--- a/tests/Type/Symfony/data/response_header_bag_get_cookies.php
+++ b/tests/Type/Symfony/data/response_header_bag_get_cookies.php
@@ -8,4 +8,5 @@ $headerBag = new ResponseHeaderBag();
 $headerBag->setCookie(Cookie::create('cookie_name'));
 
 assertType('array<int, Symfony\Component\HttpFoundation\Cookie>', $headerBag->getCookies());
+assertType('array<int, Symfony\Component\HttpFoundation\Cookie>', $headerBag->getCookies(ResponseHeaderBag::COOKIES_FLAT));
 assertType('array<string, array<string, array<string, Symfony\Component\HttpFoundation\Cookie>>>', $headerBag->getCookies(ResponseHeaderBag::COOKIES_ARRAY));

--- a/tests/Type/Symfony/data/response_header_bag_get_cookies.php
+++ b/tests/Type/Symfony/data/response_header_bag_get_cookies.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types = 1);
+
+use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use function PHPStan\Testing\assertType;
+
+$headerBag = new ResponseHeaderBag();
+$headerBag->setCookie(Cookie::create('cookie_name'));
+
+assertType('array<int, Symfony\Component\HttpFoundation\Cookie>', $headerBag->getCookies());
+assertType('array<string, array<string, array<string, Symfony\Component\HttpFoundation\Cookie>>>', $headerBag->getCookies(ResponseHeaderBag::COOKIES_ARRAY));


### PR DESCRIPTION
An attempt to make `ResponseHeaderBag::getCookies()` return dynamic type based on:
 https://github.com/symfony/symfony/blob/c112bf116f8d4eb2d44a70dffaed8d7f4f10e521/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L225

which when `array` is passed, returns `$this->cookies` which contains:

https://github.com/symfony/symfony/blob/c112bf116f8d4eb2d44a70dffaed8d7f4f10e521/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php#L184