### PR TITLE
Remove nullable type on `InputBag::get()` after `InputBag::has()` call

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -278,3 +278,8 @@ services:
 	-
 		factory: PHPStan\Type\Symfony\ResponseHeaderBagDynamicReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+	# InputBag::get() type specification
+	-
+		factory: PHPStan\Type\Symfony\InputBagTypeSpecifyingExtension
+		tags: [phpstan.typeSpecifier.methodTypeSpecifyingExtension]

--- a/src/Type/Symfony/InputBagTypeSpecifyingExtension.php
+++ b/src/Type/Symfony/InputBagTypeSpecifyingExtension.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\MethodTypeSpecifyingExtension;
+use PHPStan\Type\TypeCombinator;
+use Symfony\Component\HttpFoundation\InputBag;
+
+final class InputBagTypeSpecifyingExtension implements MethodTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+
+	private const INPUT_BAG_CLASS = InputBag::class;
+	private const HAS_METHOD_NAME = 'has';
+	private const GET_METHOD_NAME = 'get';
+
+	/** @var ReflectionProvider */
+	private $reflectionProvider;
+
+	/** @var TypeSpecifier */
+	private $typeSpecifier;
+
+	public function __construct(ReflectionProvider $reflectionProvider)
+	{
+		$this->reflectionProvider = $reflectionProvider;
+	}
+
+	public function getClass(): string
+	{
+		return self::INPUT_BAG_CLASS;
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
+	{
+		return $methodReflection->getName() === self::HAS_METHOD_NAME && !$context->null();
+	}
+
+	public function specifyTypes(MethodReflection $methodReflection, MethodCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes
+	{
+		$classReflection = $this->reflectionProvider->getClass(self::INPUT_BAG_CLASS);
+		$methodVariants = $classReflection->getNativeMethod(self::GET_METHOD_NAME)->getVariants();
+		$returnType = ParametersAcceptorSelector::selectSingle($methodVariants)->getReturnType();
+
+		if (!TypeCombinator::containsNull($returnType)) {
+			return new SpecifiedTypes();
+		}
+
+		return $this->typeSpecifier->create(
+			new MethodCall($node->var, self::GET_METHOD_NAME, $node->getArgs()),
+			TypeCombinator::removeNull($returnType),
+			$context
+		);
+	}
+
+	public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+	{
+		$this->typeSpecifier = $typeSpecifier;
+	}
+
+}

--- a/tests/Type/Symfony/data/input_bag.php
+++ b/tests/Type/Symfony/data/input_bag.php
@@ -5,6 +5,12 @@ use function PHPStan\Testing\assertType;
 $bag = new \Symfony\Component\HttpFoundation\InputBag(['foo' => 'bar', 'bar' => ['x']]);
 
 assertType('bool|float|int|string|null', $bag->get('foo'));
+
+if ($bag->has('foo')) {
+	assertType('bool|float|int|string', $bag->get('foo'));
+	assertType('bool|float|int|string|null', $bag->get('bar'));
+}
+
 assertType('bool|float|int|string|null', $bag->get('foo', null));
 assertType('bool|float|int|string', $bag->get('foo', ''));
 assertType('bool|float|int|string', $bag->get('foo', 'baz'));


### PR DESCRIPTION
I've used https://github.com/phpstan/phpstan-symfony/blob/df5ce326a8935bf400eb59f7080e568c20ef6246/src/Type/Symfony/RequestTypeSpecifyingExtension.php as example.

**Update**: maybe we could change it to a `HasGetTypeSpecifyingExtension` and pass the `className` so it can be reused for other classes as well.