### PR TITLE
Support for `ServiceProviderInterface`

### DIFF
--- a/tests/Rules/Symfony/ExampleController.php
+++ b/tests/Rules/Symfony/ExampleController.php
@@ -39,9 +39,4 @@ final class ExampleController extends Controller
 		$this->get('unknown');
 	}
 
-	public function privateServiceFromServiceLocator(): void
-	{
-		$this->get('service_locator')->get('private');
-	}
-
 }

--- a/tests/Rules/Symfony/container.xml
+++ b/tests/Rules/Symfony/container.xml
@@ -3,10 +3,5 @@
     <services>
         <service id="private" class="Foo" public="false"></service>
         <service id="public" class="Foo"></service>
-        <service id="service_locator" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
-            <argument type="collection">
-                <argument key="private" type="service" id="private"/>
-            </argument>
-        </service>
     </services>
 </container>


### PR DESCRIPTION
@ondrejmirtes I've added support for `ServiceProviderInterface` and checked it against our codebase - after my changes and implementing this interface in our locators (mentioned [here](https://github.com/phpstan/phpstan-symfony/pull/151#issuecomment-1031578839)) I don't have errors, so rule is working properly.

But I had tough time with this mostly because of test scenario provided in #151 which IMHO does not work as expected. I started by adding `ExampleController::privateServiceFromServiceProvider()` but wanted to make it fail and I couldn't. After several tries I just checked what will happen if I remove `$isServiceLocator` from `ContainerInterfacePrivateServiceRule` and... tests were still green. So I've just removed those services from `tests/Rules/Symfony/container.xml` completely and I would like to provide proper test cases for service locator/provider but I don't know how 😅 I've tried to create some example files, loaded in new test method within `ContainerInterfacePrivateServiceRuleTest`, but I did not manage to achieve failing scenario, which could be fixed by my changes. Could you help me with this (or @lookyman)?