### PR TITLE
Support for parameterised service class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "phpstan/phpstan": "^1.4"
   },
   "conflict": {
+    "psr/container": "1.1.2",
     "symfony/framework-bundle": "<3.0"
   },
   "require-dev": {
@@ -28,6 +29,7 @@
     "phpunit/phpunit": "^9.5",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/console": "^4.0 || ^5.0",
+    "symfony/dependency-injection": "^4.0 || ^5.0",
     "symfony/form": "^4.0 || ^5.0",
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/http-foundation": "^5.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.0",
     "phpunit/phpunit": "^9.5",
-    "psr/container": "^1.1 <1.1.2",
+    "psr/container": "1.0 || 1.1.1",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/console": "^4.0 || ^5.0",
     "symfony/dependency-injection": "^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
     "phpstan/phpstan": "^1.4"
   },
   "conflict": {
-    "psr/container": "1.1.2",
     "symfony/framework-bundle": "<3.0"
   },
   "require-dev": {
@@ -27,6 +26,7 @@
     "phpstan/phpstan-phpunit": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.0",
     "phpunit/phpunit": "^9.5",
+    "psr/container": "^1.1 <1.1.2",
     "symfony/config": "^4.2 || ^5.0",
     "symfony/console": "^4.0 || ^5.0",
     "symfony/dependency-injection": "^4.0 || ^5.0",

--- a/tests/Type/Symfony/container.xml
+++ b/tests/Type/Symfony/container.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <parameters>
+        <parameter key="app.class">Foo</parameter>
         <parameter key="app.string">abcdef</parameter>
         <parameter key="app.int">123</parameter>
         <parameter key="app.int_as_string" type="string">123</parameter>
@@ -51,6 +52,7 @@
 
     <services>
         <service id="foo" class="Foo" public="true"></service>
+        <service id="parameterised_foo" class="%app.class%"></service>
         <service id="synthetic" class="Synthetic" public="true" synthetic="true" />
     </services>
 </container>

--- a/tests/Type/Symfony/container.xml
+++ b/tests/Type/Symfony/container.xml
@@ -53,6 +53,7 @@
     <services>
         <service id="foo" class="Foo" public="true"></service>
         <service id="parameterised_foo" class="%app.class%"></service>
+        <service id="parameterised_bar" class="%app.class%\Bar"></service>
         <service id="synthetic" class="Synthetic" public="true" synthetic="true" />
     </services>
 </container>

--- a/tests/Type/Symfony/data/ExampleAbstractController.php
+++ b/tests/Type/Symfony/data/ExampleAbstractController.php
@@ -14,6 +14,7 @@ final class ExampleAbstractController extends AbstractController
 	{
 		assertType('Foo', $this->get('foo'));
 		assertType('Foo', $this->get('parameterised_foo'));
+		assertType('Foo\Bar', $this->get('parameterised_bar'));
 		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));

--- a/tests/Type/Symfony/data/ExampleAbstractController.php
+++ b/tests/Type/Symfony/data/ExampleAbstractController.php
@@ -13,6 +13,7 @@ final class ExampleAbstractController extends AbstractController
 	public function services(): void
 	{
 		assertType('Foo', $this->get('foo'));
+		assertType('Foo', $this->get('parameterised_foo'));
 		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));

--- a/tests/Type/Symfony/data/ExampleController.php
+++ b/tests/Type/Symfony/data/ExampleController.php
@@ -13,6 +13,7 @@ final class ExampleController extends Controller
 	public function services(): void
 	{
 		assertType('Foo', $this->get('foo'));
+		assertType('Foo', $this->get('parameterised_foo'));
 		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));

--- a/tests/Type/Symfony/data/ExampleController.php
+++ b/tests/Type/Symfony/data/ExampleController.php
@@ -14,6 +14,7 @@ final class ExampleController extends Controller
 	{
 		assertType('Foo', $this->get('foo'));
 		assertType('Foo', $this->get('parameterised_foo'));
+		assertType('Foo\Bar', $this->get('parameterised_bar'));
 		assertType('Synthetic', $this->get('synthetic'));
 		assertType('object', $this->get('bar'));
 		assertType('object', $this->get(doFoo()));


### PR DESCRIPTION
Fixes #226

~~It's simplest and optimistic implementation which does not support:~~
- ~~`%env()%` syntax~~
- ~~`%app.class%_decorator` mixed interpolation~~

Let me know if we can start with this or should we work on most advanced scenarios 🙂 