### PR TITLE
Update DenormalizerInterface::denormalize

### DIFF
--- a/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
@@ -9,7 +9,7 @@ interface DenormalizerInterface
      * @param string $type
      * @param string|null $format
      * @param array<mixed> $context
-     * @return object|array<mixed>
+     * @return mixed
      */
     public function denormalize($data, $type, $format = null, array $context = []);
 


### PR DESCRIPTION
Hi @ondrejmirtes

The stub from phpstan-symfony is restricting the return type to object|array, but there is no restriction in the interface from Symfony ; cf https://github.com/symfony/Serializer/blob/6.1/Normalizer/DenormalizerInterface.php.

So I changed the return type to `mixed` like the one from Symfony. 