### PR TITLE
Add missing Request.stub to extension.neon

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -33,6 +33,7 @@ parameters:
 		- stubs/Symfony/Component/HttpFoundation/Cookie.stub
 		- stubs/Symfony/Component/HttpFoundation/HeaderBag.stub
 		- stubs/Symfony/Component/HttpFoundation/ParameterBag.stub
+		- stubs/Symfony/Component/HttpFoundation/Request.stub
 		- stubs/Symfony/Component/HttpFoundation/Session.stub
 		- stubs/Symfony/Component/Messenger/StampInterface.stub
 		- stubs/Symfony/Component/Messenger/Envelope.stub


### PR DESCRIPTION
On our project, we were hoping for this feature be available https://github.com/phpstan/phpstan-symfony/commit/012305dab7a08f4e1a7158e01d7b4bccfbc6fa31

But it's not by default because the extension.neon file doesn't contain this stub by default.

This PR fixes it.