### PR TITLE
add documentation to load DI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ parameters:
     # If you're using PHP config files for Symfony 5.3+, you also need this for auto-loading of `Symfony\Config`:
     scanDirectories:
         - var/cache/dev/Symfony/Config
+    # If you're using PHP config files you need this to load the helper functions (i.e. service())
+    scanFiles:
+        - vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php
 ```
 
 ## Constant hassers


### PR DESCRIPTION
Fixes #269, https://github.com/phpstan/phpstan/issues/7118.

As mentioned in https://github.com/symfony/symfony/pull/46214 this will not be changed in Symfony, so I added it to the documentation here.