### PR TITLE
Revert "add documentation to load DI helper" #271

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ parameters:
     # If you're using PHP config files for Symfony 5.3+, you also need this for auto-loading of `Symfony\Config`:
     scanDirectories:
         - var/cache/dev/Symfony/Config
-    # If you're using PHP config files you need this to load the helper functions (i.e. service())
-    scanFiles:
-        - vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php
 ```
 
 ## Constant hassers


### PR DESCRIPTION
This reverts commit b1c515245615797c081105be04d5741c3deda843.

This is not needed after all: https://github.com/phpstan/phpstan-symfony/issues/269#issuecomment-1118467915