### PR TITLE
Fix formInterface stub

### DIFF
--- a/stubs/Symfony/Component/Form/FormInterface.stub
+++ b/stubs/Symfony/Component/Form/FormInterface.stub
@@ -3,9 +3,10 @@
 namespace Symfony\Component\Form;
 
 /**
- * @extends \Traversable<string|int, \Symfony\Component\Form\FormInterface>
+ * @extends \ArrayAccess<string, \Symfony\Component\Form\FormInterface>
+ * @extends \Traversable<string, \Symfony\Component\Form\FormInterface>
  */
-interface FormInterface extends \Traversable
+interface FormInterface extends \ArrayAccess, \Traversable, \Countable
 {
 
 }


### PR DESCRIPTION
Hi @ondrejmirtes,  

A formInterface is not `\Traversable<int|string, \Symfony\Component\Form\FormInterface>` but `\Traversable<string, \Symfony\Component\Form\FormInterface>`

From https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Form/FormInterface.php#L21-L24