### PR TITLE
Fix exception thrown by Command::run

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -21,7 +21,9 @@ parameters:
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
 		- stubs/Symfony/Component/Console/Command.stub
+		- stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
 		- stubs/Symfony/Component/Console/Helper/HelperInterface.stub
+		- stubs/Symfony/Component/Console/Input/InputInterface.stub
 		- stubs/Symfony/Component/Console/Output/OutputInterface.stub
 		- stubs/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.stub
 		- stubs/Symfony/Component/DependencyInjection/ContainerBuilder.stub

--- a/stubs/Symfony/Component/Console/Command.stub
+++ b/stubs/Symfony/Component/Console/Command.stub
@@ -2,10 +2,19 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
 class Command
 {
     /**
      * @return \Symfony\Component\Console\Helper\HelperInterface
      */
     public function getHelper(string $name);
+
+    /**
+     * @throws ExceptionInterface
+     */
+    public function run(InputInterface $input, OutputInterface $output): int;
 }

--- a/stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
+++ b/stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/stubs/Symfony/Component/Console/Input/InputInterface.stub
+++ b/stubs/Symfony/Component/Console/Input/InputInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Input;
+
+interface InputInterface
+{
+}


### PR DESCRIPTION
Command::run is doing
```
try {
     $input->bind($this->definition);
} catch (ExceptionInterface $e) {
     if (!$this->ignoreValidationErrors) {
          throw $e;
    }
}
```
And the bind method is only throwing `ExceptionInterface` so the run method is supposed to thrown only `ExceptionInterface` and not `\Exception` which is too generic.

This avoid error with static analysis when we ignore some kind of exception thrown.