### PR TITLE
Add stub for VoterInterface

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -40,6 +40,8 @@ parameters:
 		- stubs/Symfony/Component/PropertyAccess/PropertyPathInterface.stub
 		- stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub
 		- stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub
+		- stubs/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.stub
+		- stubs/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub

--- a/stubs/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.stub
+++ b/stubs/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authentication\Token;
+
+interface TokenInterface
+{
+}

--- a/stubs/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.stub
+++ b/stubs/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Symfony\Component\Security\Core\Authorization\Voter;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+interface VoterInterface
+{
+	/**
+	 * @param mixed   $subject
+	 * @param mixed[] $attributes
+	 *
+	 * @return int
+	 */
+	public function vote(TokenInterface $token, $subject, array $attributes);
+}


### PR DESCRIPTION
To type the `$attributes` with `mixed[]` instead of `array` to be OK until level 9 at least