### PR TITLE
Remove Stringable from the `OutputInterface::write()` signature, it's actually not supported

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -15,7 +15,6 @@ parameters:
 		skipCheckGenericClasses:
 			- Symfony\Component\OptionsResolver\Options
 	stubFiles:
-		- stubs/Php/Stringable.stub
 		- stubs/Psr/Cache/CacheItemInterface.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/KernelBrowser.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub

--- a/stubs/Php/Stringable.stub
+++ b/stubs/Php/Stringable.stub
@@ -1,5 +1,0 @@
-<?php
-
-interface Stringable
-{
-}

--- a/stubs/Symfony/Component/Console/Output/OutputInterface.stub
+++ b/stubs/Symfony/Component/Console/Output/OutputInterface.stub
@@ -17,13 +17,13 @@ interface OutputInterface
     public const OUTPUT_PLAIN = 4;
 
     /**
-     * @param string|Stringable|iterable<string|Stringable> $messages
+     * @param string|iterable<string> $messages
      * @param int-mask-of<self::VERBOSITY_*|self::OUTPUT_*> $options
      */
     public function write($messages, bool $newline = false, int $options = 0): void;
 
     /**
-     * @param string|Stringable|iterable<string|Stringable> $messages
+     * @param string|iterable<string> $messages
      * @param int-mask-of<self::VERBOSITY_*|self::OUTPUT_*> $options
      */
     public function writeln($messages, int $options = 0): void;


### PR DESCRIPTION
I did made a mistake to include Stringable in the OutputInterface signature in #293.
While it works with Symfony 5 because it's typehinted via phpdoc, it fails with Symfony 6 with native type hints.