### PR TITLE
Add @throws annotation to DataTransformerInterface

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -22,12 +22,15 @@ parameters:
 		- stubs/Symfony/Component/Console/Command.stub
 		- stubs/Symfony/Component/Console/Helper/HelperInterface.stub
 		- stubs/Symfony/Component/Console/Output/OutputInterface.stub
-		- stubs/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.stub
 		- stubs/Symfony/Component/DependencyInjection/ContainerBuilder.stub
 		- stubs/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.stub
 		- stubs/Symfony/Component/EventDispatcher/EventDispatcherInterface.stub
 		- stubs/Symfony/Component/EventDispatcher/EventSubscriberInterface.stub
 		- stubs/Symfony/Component/EventDispatcher/GenericEvent.stub
+		- stubs/Symfony/Component/Form/ChoiceList/Loader/ChoiceLoaderInterface.stub
+		- stubs/Symfony/Component/Form/Exception/ExceptionInterface.stub
+		- stubs/Symfony/Component/Form/Exception/RuntimeException.stub
+		- stubs/Symfony/Component/Form/Exception/TransformationFailedException.stub
 		- stubs/Symfony/Component/Form/DataTransformerInterface.stub
 		- stubs/Symfony/Component/Form/FormBuilderInterface.stub
 		- stubs/Symfony/Component/Form/FormInterface.stub

--- a/stubs/Symfony/Component/Form/DataTransformerInterface.stub
+++ b/stubs/Symfony/Component/Form/DataTransformerInterface.stub
@@ -14,6 +14,8 @@ interface DataTransformerInterface
      * @phpstan-param T|null $value The value in the original representation
      *
      * @phpstan-return R|null The value in the transformed representation
+     *
+     * @throws TransformationFailedException
      */
     public function transform($value);
 
@@ -21,6 +23,8 @@ interface DataTransformerInterface
      * @phpstan-param R|null $value The value in the transformed representation
      *
      * @phpstan-return T|null The value in the original representation
+     *
+     * @throws TransformationFailedException
      */
     public function reverseTransform($value);
 }

--- a/stubs/Symfony/Component/Form/Exception/ExceptionInterface.stub
+++ b/stubs/Symfony/Component/Form/Exception/ExceptionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Form\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/stubs/Symfony/Component/Form/Exception/RuntimeException.stub
+++ b/stubs/Symfony/Component/Form/Exception/RuntimeException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Form\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Form/Exception/TransformationFailedException.stub
+++ b/stubs/Symfony/Component/Form/Exception/TransformationFailedException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Form\Exception;
+
+class TransformationFailedException extends RuntimeException
+{
+}


### PR DESCRIPTION
This seems to be an issue similar to the lost @phpstan-type in stubs

Since there is no `@throws` in the stub, Phpstan consider that no exception are thrown, until using the real interface definition. I would have expect
- Use @throw void in the stub to override the interface
- No @throw = default definition from the interface

This would be fixed this way by the whole changed made in https://github.com/phpstan/phpstan-src/pull/1603

Until this is globally fixed (or not if considered as normal behavior...), I made a PR to fix the stub here @ondrejmirtes 