### PR TITLE
Skip check for negatable input options on symfony/console < 5.3

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Call to function method_exists\\(\\) with Symfony\\\\Component\\\\Console\\\\Input\\\\InputOption and 'isNegatable' will always evaluate to true\\.$#"
+			count: 1
+			path: src/Type/Symfony/GetOptionTypeHelper.php
+
+		-
 			message: "#^Accessing PHPStan\\\\Rules\\\\Methods\\\\CallMethodsRule\\:\\:class is not covered by backward compatibility promise\\. The class might change in a minor PHPStan version\\.$#"
 			count: 1
 			path: tests/Rules/NonexistentInputBagClassTest.php

--- a/src/Type/Symfony/GetOptionTypeHelper.php
+++ b/src/Type/Symfony/GetOptionTypeHelper.php
@@ -12,6 +12,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\UnionType;
 use Symfony\Component\Console\Input\InputOption;
+use function method_exists;
 
 class GetOptionTypeHelper
 {
@@ -19,7 +20,7 @@ class GetOptionTypeHelper
 	public function getOptionType(Scope $scope, InputOption $option): Type
 	{
 		if (!$option->acceptValue()) {
-			if ($option->isNegatable()) {
+			if (method_exists($option, 'isNegatable') && $option->isNegatable()) {
 				return new UnionType([new BooleanType(), new NullType()]);
 			}
 


### PR DESCRIPTION
This fixes a regression introduced with #300 where the `InputOption::isNegatable()` method is not available for `symfony/console` < 5.3.0.