### PR TITLE
Fix Envelope::all() return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "ext-simplexml": "*",
-    "phpstan/phpstan": "^1.8.2"
+    "phpstan/phpstan": "^1.9.1"
   },
   "conflict": {
     "symfony/framework-bundle": "<3.0"

--- a/src/Type/Symfony/EnvelopeReturnTypeExtension.php
+++ b/src/Type/Symfony/EnvelopeReturnTypeExtension.php
@@ -5,10 +5,12 @@ namespace PHPStan\Type\Symfony;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Type\MixedType;
+use PHPStan\Type\Generic\GenericClassStringType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 use function count;
@@ -33,15 +35,18 @@ final class EnvelopeReturnTypeExtension implements DynamicMethodReturnTypeExtens
 	): Type
 	{
 		if (count($methodCall->getArgs()) === 0) {
-			return new ArrayType(new MixedType(), new ArrayType(new MixedType(), new ObjectType('Symfony\Component\Messenger\Stamp\StampInterface')));
+			return new ArrayType(
+				new GenericClassStringType(new ObjectType('Symfony\Component\Messenger\Stamp\StampInterface')),
+				AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new ObjectType('Symfony\Component\Messenger\Stamp\StampInterface')))
+			);
 		}
 
 		$argType = $scope->getType($methodCall->getArgs()[0]->value);
 		if (!$argType instanceof ConstantStringType) {
-			return new ArrayType(new MixedType(), new ObjectType('Symfony\Component\Messenger\Stamp\StampInterface'));
+			return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new ObjectType('Symfony\Component\Messenger\Stamp\StampInterface')));
 		}
 
-		return new ArrayType(new MixedType(), new ObjectType($argType->getValue()));
+		return AccessoryArrayListType::intersectWith(new ArrayType(new IntegerType(), new ObjectType($argType->getValue())));
 	}
 
 }

--- a/stubs/Symfony/Component/Messenger/Envelope.stub
+++ b/stubs/Symfony/Component/Messenger/Envelope.stub
@@ -14,11 +14,4 @@ final class Envelope
     public function last(string $stampFqcn): ?StampInterface
     {
     }
-    
-    /**
-     * @return ($stampFqcn is null ? array<string, list<StampInterface>> : list<StampInterface>)
-     */
-    public function all(?string $stampFqcn = null): array
-    {
-    }
 }

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -76,6 +76,7 @@ class ExtensionTest extends TypeInferenceTestCase
 		return [
 			__DIR__ . '/../../../extension.neon',
 			__DIR__ . '/extension-test.neon',
+			'phar://' . __DIR__ . '/../../../vendor/phpstan/phpstan/phpstan.phar/conf/bleedingEdge.neon',
 		];
 	}
 

--- a/tests/Type/Symfony/data/envelope_all.php
+++ b/tests/Type/Symfony/data/envelope_all.php
@@ -4,6 +4,6 @@ use function PHPStan\Testing\assertType;
 
 $envelope = new \Symfony\Component\Messenger\Envelope(new stdClass());
 
-assertType('array<Symfony\Component\Messenger\Stamp\ReceivedStamp>', $envelope->all(\Symfony\Component\Messenger\Stamp\ReceivedStamp::class));
-assertType('array<Symfony\Component\Messenger\Stamp\StampInterface>', $envelope->all(random_bytes(1)));
-assertType('array<array<Symfony\Component\Messenger\Stamp\StampInterface>>', $envelope->all());
+assertType('list<Symfony\Component\Messenger\Stamp\ReceivedStamp>', $envelope->all(\Symfony\Component\Messenger\Stamp\ReceivedStamp::class));
+assertType('list<Symfony\Component\Messenger\Stamp\StampInterface>', $envelope->all(random_bytes(1)));
+assertType('array<class-string<Symfony\Component\Messenger\Stamp\StampInterface>, list<Symfony\Component\Messenger\Stamp\StampInterface>>', $envelope->all());


### PR DESCRIPTION
I noticed that my fix from #308 wasn't working so I looked deeper into it. Trying a better fix now.