### PR TITLE
Add stub for AbstractType

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -13,6 +13,10 @@ parameters:
 		consoleApplicationLoader: null
 	featureToggles:
 		skipCheckGenericClasses:
+			- Symfony\Component\Form\AbstractType
+			- Symfony\Component\Form\AbstractTypeExtension
+			- Symfony\Component\Form\FormTypeExtensionInterface
+			- Symfony\Component\Form\FormTypeInterface
 			- Symfony\Component\OptionsResolver\Options
 	stubFiles:
 		- stubs/Psr/Cache/CacheItemInterface.stub
@@ -31,6 +35,8 @@ parameters:
 		- stubs/Symfony/Component/Form/Exception/ExceptionInterface.stub
 		- stubs/Symfony/Component/Form/Exception/RuntimeException.stub
 		- stubs/Symfony/Component/Form/Exception/TransformationFailedException.stub
+		- stubs/Symfony/Component/Form/AbstractType.stub
+		- stubs/Symfony/Component/Form/AbstractTypeExtension.stub
 		- stubs/Symfony/Component/Form/DataTransformerInterface.stub
 		- stubs/Symfony/Component/Form/FormBuilderInterface.stub
 		- stubs/Symfony/Component/Form/FormInterface.stub

--- a/stubs/Symfony/Component/Form/AbstractType.stub
+++ b/stubs/Symfony/Component/Form/AbstractType.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+/**
+ * @template T
+ * @implements FormTypeInterface<T>
+ */
+abstract class AbstractType implements FormTypeInterface
+{
+}

--- a/stubs/Symfony/Component/Form/AbstractTypeExtension.stub
+++ b/stubs/Symfony/Component/Form/AbstractTypeExtension.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Form;
+
+/**
+ * @template T
+ * @implements FormTypeExtensionInterface<T>
+ */
+abstract class AbstractTypeExtension implements FormTypeExtensionInterface
+{
+}

--- a/stubs/Symfony/Component/Form/FormTypeExtensionInterface.stub
+++ b/stubs/Symfony/Component/Form/FormTypeExtensionInterface.stub
@@ -2,19 +2,27 @@
 
 namespace Symfony\Component\Form;
 
+/**
+ * @template T
+ */
 interface FormTypeExtensionInterface
 {
     /**
+     * @param FormBuilderInterface<T> $builder
      * @param array<string, mixed> $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void;
 
     /**
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void;
 
     /**
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      * @param array<string, mixed> $options
      */
     public function finishView(FormView $view, FormInterface $form, array $options): void;

--- a/stubs/Symfony/Component/Form/FormTypeInterface.stub
+++ b/stubs/Symfony/Component/Form/FormTypeInterface.stub
@@ -2,19 +2,27 @@
 
 namespace Symfony\Component\Form;
 
+/**
+ * @template T
+ */
 interface FormTypeInterface
 {
     /**
+     * @param FormBuilderInterface<T> $builder
      * @param array<string, mixed> $options
      */
     public function buildForm(FormBuilderInterface $builder, array $options): void;
 
     /**
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      * @param array<string, mixed> $options
      */
     public function buildView(FormView $view, FormInterface $form, array $options): void;
 
     /**
+     * @param FormView<T> $view
+     * @param FormInterface<T> $form
      * @param array<string, mixed> $options
      */
     public function finishView(FormView $view, FormInterface $form, array $options): void;


### PR DESCRIPTION
This PR adds stubs for `Symfony\Component\Form\AbstractType` and `Symfony\Component\Form\AbstractTypeExtension`.

After upgrading to Psalm 5, it requires `@template-extends AbstractType<int>` annotation when extending `AbstractType`, but currently phpstan complains about this. 

Adding these stubs creates parity with [psalm/psalm-plugin-symfony](https://github.com/psalm/psalm-plugin-symfony/tree/5.x/src/Stubs/common/Component/Form) regarding those classes.