### PR TITLE
Add generics for PasswordUpgraderInterface

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -14,6 +14,7 @@ parameters:
 	featureToggles:
 		skipCheckGenericClasses:
 			- Symfony\Component\OptionsResolver\Options
+			- Symfony\Component\Security\Core\User\PasswordUpgraderInterface
 	stubFiles:
 		- stubs/Psr/Cache/CacheItemInterface.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/KernelBrowser.stub

--- a/extension.neon
+++ b/extension.neon
@@ -50,6 +50,8 @@ parameters:
 		- stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub
 		- stubs/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.stub
 		- stubs/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.stub
+		- stubs/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.stub
+		- stubs/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub

--- a/stubs/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.stub
+++ b/stubs/Symfony/Component/Security/Core/User/PasswordAuthenticatedUserInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Security\Core\User;
+
+interface PasswordAuthenticatedUserInterface
+{
+}

--- a/stubs/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.stub
+++ b/stubs/Symfony/Component/Security/Core/User/PasswordUpgraderInterface.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Security\Core\User;
+
+/**
+ * @template TUser of PasswordAuthenticatedUserInterface
+ */
+interface PasswordUpgraderInterface
+{
+	/**
+	 * @param TUser $user
+	 */
+	public function upgradePassword(PasswordAuthenticatedUserInterface $user, string $newHashedPassword): void;
+}


### PR DESCRIPTION
This is https://github.com/symfony/symfony/pull/48750 but for older Symfony version.
I'll wait for the Symfony merge this.