### PR TITLE
Revert wrong typehint for getSession return type

### DIFF
--- a/stubs/Symfony/Component/HttpFoundation/Request.stub
+++ b/stubs/Symfony/Component/HttpFoundation/Request.stub
@@ -27,11 +27,6 @@ class Request
 	public $cookies;
 
     /**
-     * @return \Symfony\Component\HttpFoundation\Session\Session
-     */
-    public function getSession();
-
-    /**
      * @return string[]
      */
     public static function getTrustedProxies(): array;

--- a/tests/Type/Symfony/data/request_get_session.php
+++ b/tests/Type/Symfony/data/request_get_session.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types = 1);
 
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use function PHPStan\Testing\assertType;
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
 $request = doRequest();
 
 $session1 = $request->getSession();
-assertType(Session::class, $request->getSession());
+assertType(SessionInterface::class, $request->getSession());
 
 if ($request->hasSession()) {
-	assertType(Session::class, $request->getSession());
+	assertType(SessionInterface::class, $request->getSession());
 }

--- a/tests/Type/Symfony/data/request_get_session_null.php
+++ b/tests/Type/Symfony/data/request_get_session_null.php
@@ -1,14 +1,14 @@
 <?php declare(strict_types = 1);
 
-use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use function PHPStan\Testing\assertType;
 
 /** @var \Symfony\Component\HttpFoundation\Request $request */
 $request = doRequest();
 
 $session1 = $request->getSession();
-assertType(Session::class . '|null', $request->getSession());
+assertType(SessionInterface::class . '|null', $request->getSession());
 
 if ($request->hasSession()) {
-	assertType(Session::class, $request->getSession());
+	assertType(SessionInterface::class, $request->getSession());
 }


### PR DESCRIPTION
TLDR: This would be one way to closes https://github.com/phpstan/phpstan-symfony/issues/323, and IMHO it's the best one because
- it's correct in 100% of the time for Symfony users and promotes to right correct code.
- People who doesn't care about the Session/SessionInterface can ignore the error.
- People who care about the Session/SessionInterface are not dealing with wrong errors.

-----------------

This type hint was introduced by
https://github.com/phpstan/phpstan-symfony/commit/012305dab7a08f4e1a7158e01d7b4bccfbc6fa31
which was done to replace the original PR
https://github.com/phpstan/phpstan-symfony/pull/233 cc @ruudk 

As explained in https://github.com/symfony/symfony/issues/39222#issuecomment-735469831
or https://github.com/symfony/symfony/issues/41765#issuecomment-870268556:
- This is not true that `getSession` always return a Session
- People should rely on a `instanceof` checks
This is even easier now that the `FlashBagAwareSessionInterface` was introduced in https://github.com/symfony/symfony/issues/41765.

It was said by @ruudk 
> For a small set of users it could mean that phpstan now falsely allows getFlashBag on the request session, because they have a custom session implementation. They prob didn't call the flashbag anyway, as it doesn't work.

But this is not the real problem of the stub.
The real issue is that if you use service decoration, or write correctly your calls to support multiple sessions, like
```
$session = $request->getSession();
if ($session instanceof FlashBagAwareSessionInterface) {
     $session->getFlashBag()->addMessage('Foo');
} elseif ($session instanceof MyCustomSessionInterface) {
     $session->doThings();
} else {
     // ...
}
```
You ended up with false positive from phpstan about `always true instanceof` or `always false instanceof`.
This is way better to have a "false negative" (`getFlashBag() doesn't exist in SessionInterface) than introducing false positive.

If people doesn't want to write correct code about Symfony session, they should ignore the error 
```
ignoreErros:
     - '#Call to an undefined method Symfony\\Component\\HttpFoundation\\Session\\SessionInterface::getFlashBag\(\)#'
```
rather than introducing a wrong stub.

Closes https://github.com/phpstan/phpstan-symfony/issues/323