### PR TITLE
Extend NormalizerInterface::normalize return type, add @throws to NormalizerInterface and DenormalizerInterface

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -58,6 +58,14 @@ parameters:
 		- stubs/Symfony/Component/Serializer/Encoder/ContextAwareDecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
 		- stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub
+		- stubs/Symfony/Component/Serializer/Exception/BadMethodCallException.stub
+		- stubs/Symfony/Component/Serializer/Exception/CircularReferenceException.stub
+		- stubs/Symfony/Component/Serializer/Exception/ExceptionInterface.stub
+		- stubs/Symfony/Component/Serializer/Exception/ExtraAttributesException.stub
+		- stubs/Symfony/Component/Serializer/Exception/InvalidArgumentException.stub
+		- stubs/Symfony/Component/Serializer/Exception/LogicException.stub
+		- stubs/Symfony/Component/Serializer/Exception/RuntimeException.stub
+		- stubs/Symfony/Component/Serializer/Exception/UnexpectedValueException.stub
 		- stubs/Symfony/Component/Serializer/Normalizer/ContextAwareDenormalizerInterface.stub
 		- stubs/Symfony/Component/Serializer/Normalizer/ContextAwareNormalizerInterface.stub
 		- stubs/Symfony/Component/Serializer/Normalizer/DenormalizableInterface.stub

--- a/stubs/Symfony/Component/Serializer/Exception/BadMethodCallException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/BadMethodCallException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/CircularReferenceException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/CircularReferenceException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class CircularReferenceException extends RuntimeException
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/ExceptionInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/ExceptionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/ExtraAttributesException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/ExtraAttributesException.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class ExtraAttributesException extends RuntimeException
+{
+    /**
+     * @param string[] $extraAttributes
+     */
+    public function __construct(array $extraAttributes, \Throwable $previous = null)
+    {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExtraAttributes()
+    {
+    }
+}

--- a/stubs/Symfony/Component/Serializer/Exception/InvalidArgumentException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/InvalidArgumentException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/LogicException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/LogicException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/RuntimeException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/RuntimeException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Exception/UnexpectedValueException.stub
+++ b/stubs/Symfony/Component/Serializer/Exception/UnexpectedValueException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Exception;
+
+class UnexpectedValueException extends \UnexpectedValueException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
@@ -2,6 +2,14 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\Serializer\Exception\BadMethodCallException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Exception\ExtraAttributesException;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
+use Symfony\Component\Serializer\Exception\RuntimeException;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+
 interface DenormalizerInterface
 {
     /**
@@ -10,6 +18,14 @@ interface DenormalizerInterface
      * @param string|null $format
      * @param array<mixed> $context
      * @return mixed
+     *
+     * @throws BadMethodCallException
+     * @throws InvalidArgumentException
+     * @throws UnexpectedValueException
+     * @throws ExtraAttributesException
+     * @throws LogicException
+     * @throws RuntimeException
+     * @throws ExceptionInterface
      */
     public function denormalize($data, $type, $format = null, array $context = []);
 

--- a/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
@@ -2,13 +2,16 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use ArrayObject;
+
 interface NormalizerInterface
 {
     /**
      * @param mixed $object
      * @param string|null $format
      * @param array<mixed> $context
-     * @return array<mixed>|string|int|float|bool|null
+     *
+     * @return array<mixed>|ArrayObject<array-key, mixed>|string|int|float|bool|null
      */
     public function normalize($object, $format = null, array $context = []);
 

--- a/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
@@ -3,6 +3,10 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use ArrayObject;
+use Symfony\Component\Serializer\Exception\CircularReferenceException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
+use Symfony\Component\Serializer\Exception\LogicException;
 
 interface NormalizerInterface
 {
@@ -12,6 +16,11 @@ interface NormalizerInterface
      * @param array<mixed> $context
      *
      * @return array<mixed>|ArrayObject<array-key, mixed>|string|int|float|bool|null
+     *
+     * @throws InvalidArgumentException
+     * @throws CircularReferenceException
+     * @throws LogicException
+     * @throws ExceptionInterface
      */
     public function normalize($object, $format = null, array $context = []);
 


### PR DESCRIPTION
Two issues in Serializer component stubs:
- `\Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize()` can return `\ArrayObject` ([source](https://github.com/symfony/serializer/blob/v6.2.5/Normalizer/NormalizerInterface.php#L31)) – type is missing in `@return` annotation.
- Both `\Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize()` ([source](https://github.com/symfony/serializer/blob/v6.2.5/Normalizer/NormalizerInterface.php#L33-L37)) and `\Symfony\Component\Serializer\Normalizer\DenormalizerInterface::denormalize()` ([source](https://github.com/symfony/serializer/blob/v6.2.5/Normalizer/DenormalizerInterface.php#L39-L45)) throw exceptions – `@throws` annotations are missing from stubs completely. This looks like problem from #302 in another component.