### PR TITLE
Add missing @throws in stubs.

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -17,11 +17,16 @@ parameters:
 			- Symfony\Component\Security\Core\Authorization\Voter\Voter
 			- Symfony\Component\Security\Core\User\PasswordUpgraderInterface
 	stubFiles:
+		- stubs/Psr/Cache/CacheException.stub
 		- stubs/Psr/Cache/CacheItemInterface.stub
+		- stubs/Psr/Cache/InvalidArgumentException.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/KernelBrowser.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
 		- stubs/Symfony/Component/Console/Command.stub
+		- stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
+		- stubs/Symfony/Component/Console/Exception/InvalidArgumentException.stub
+		- stubs/Symfony/Component/Console/Exception/LogicException.stub
 		- stubs/Symfony/Component/Console/Helper/HelperInterface.stub
 		- stubs/Symfony/Component/Console/Output/OutputInterface.stub
 		- stubs/Symfony/Component/DependencyInjection/ContainerBuilder.stub

--- a/stubs/Psr/Cache/CacheException.stub
+++ b/stubs/Psr/Cache/CacheException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Psr\Cache;
+
+interface CacheException extends \Throwable
+{
+}

--- a/stubs/Psr/Cache/InvalidArgumentException.stub
+++ b/stubs/Psr/Cache/InvalidArgumentException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Psr\Cache;
+
+interface InvalidArgumentException extends CacheException
+{
+}

--- a/stubs/Symfony/Component/Console/Command.stub
+++ b/stubs/Symfony/Component/Console/Command.stub
@@ -2,10 +2,16 @@
 
 namespace Symfony\Component\Console\Command;
 
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\LogicException;
+
 class Command
 {
     /**
      * @return \Symfony\Component\Console\Helper\HelperInterface
+     *
+     * @throws LogicException
+     * @throws InvalidArgumentException
      */
     public function getHelper(string $name);
 }

--- a/stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
+++ b/stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/stubs/Symfony/Component/Console/Exception/InvalidArgumentException.stub
+++ b/stubs/Symfony/Component/Console/Exception/InvalidArgumentException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/Console/Exception/LogicException.stub
+++ b/stubs/Symfony/Component/Console/Exception/LogicException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Console\Exception;
+
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.stub
+++ b/stubs/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.stub
@@ -8,6 +8,8 @@ interface ExtensionInterface
 {
     /**
      * @param array<mixed> $configs
+     *
+     * @throws \InvalidArgumentException
      */
     public function load(array $configs, ContainerBuilder $container): void;
 }

--- a/stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
@@ -11,6 +11,8 @@ interface DecoderInterface
      * @param string $format
      * @param array<mixed> $context
      * @return mixed
+     *
+     * @throws UnexpectedValueException
      */
     public function decode($data, $format, array $context = []);
 

--- a/stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub
@@ -2,6 +2,8 @@
 
 namespace Symfony\Component\Serializer\Encoder;
 
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
+
 interface EncoderInterface
 {
     /**
@@ -9,6 +11,8 @@ interface EncoderInterface
      * @param string $format
      * @param array<mixed> $context
      * @return string
+     *
+     * @throws UnexpectedValueException
      */
     public function encode($data, $format, array $context = []);
 

--- a/stubs/Symfony/Contracts/Cache/CacheInterface.stub
+++ b/stubs/Symfony/Contracts/Cache/CacheInterface.stub
@@ -2,6 +2,8 @@
 
 namespace Symfony\Contracts\Cache;
 
+use Psr\Cache\InvalidArgumentException;
+
 interface CacheInterface
 {
     /**
@@ -10,6 +12,8 @@ interface CacheInterface
      * @param \Symfony\Contracts\Cache\CallbackInterface<T>|callable(\Symfony\Contracts\Cache\ItemInterface, bool): T $callback
      * @param array<mixed> $metadata
      * @return T
+     *
+     * @throws InvalidArgumentException
      */
     public function get(string $key, callable $callback, float $beta = null, array &$metadata = null);
 }


### PR DESCRIPTION
I've compared all stub files with Symfony's source files, and found some missing `@throws` tags:
- in `Symfony\Contracts\Cache\CacheInterface::get()` ([source](https://github.com/symfony/cache-contracts/blob/v1.1.6/CacheInterface.php#L43))
- in `Symfony\Component\Console\Command\Command::getHelper()` ([source](https://github.com/symfony/console/blob/v6.2.5/Command/Command.php#L686-L687))
- in `Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()` ([source](https://github.com/symfony/dependency-injection/blob/v6.2.5/Extension/ExtensionInterface.php#L28))
- in `Symfony\Component\Serializer\Encoder\EncoderInterface::encode()` ([source](https://github.com/symfony/serializer/blob/v6.2.5/Encoder/EncoderInterface.php#L28))
- in `Symfony\Component\Serializer\Encoder\DecoderInterface::decode()` ([source](https://github.com/symfony/serializer/blob/v6.2.5/Encoder/DecoderInterface.php#L35))

Exceptions should now match.