### PR TITLE
Update PHP minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "php": "^7.2 || ^8.0",
+    "php": "^7.3 || ^8.0",
     "ext-simplexml": "*",
     "phpstan/phpstan": "^1.9.4"
   },


### PR DESCRIPTION
Branch 1.2.x is not installable with PHP 7.2:

```
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - phpunit/phpunit[9.5.0, ..., 9.6.x-dev] require php >=7.3 -> your php version (7.2.34) does not satisfy that requirement.
    - Root composer.json requires phpunit/phpunit ^9.5 -> satisfiable by phpunit/phpunit[9.5.0, ..., 9.6.x-dev].
```

Edit: after making the PR, I see that we downgrade PHPUnit in the tests... :thinking: 
