### PR TITLE
Add PHPUnit compatibility for PHP 7.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,6 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2'
-        run: "composer require --dev phpunit/phpunit:^8.5.29 --no-update --update-with-dependencies"
-
       - name: "Validate Composer"
         run: "composer validate"
 
@@ -101,10 +97,6 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2'
-        run: "composer require --dev phpunit/phpunit:^8.5.29 --no-update --update-with-dependencies"
-
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
         run: "composer update --prefer-lowest --no-interaction --no-progress"
@@ -145,10 +137,6 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring
           tools: composer:v2
-
-      - name: "Downgrade PHPUnit"
-        if: matrix.php-version == '7.2'
-        run: "composer require --dev phpunit/phpunit:^8.5.29 --no-update --update-with-dependencies"
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpstan/phpstan-phpunit": "^1.0",
     "phpstan/phpstan-strict-rules": "^1.0",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^8.5.29 || ^9.5",
     "psr/container": "1.0 || 1.1.1",
     "symfony/config": "^5.4 || ^6.1",
     "symfony/console": "^5.4 || ^6.1",


### PR DESCRIPTION
Add the PHPUnit dependency for PHP 7.2 in `composer.json`.

This way we don't have to modify `composer.json` in the tests and it's compatible out of the box.