### PR TITLE
fix: Fix PHPStan errors on level 9

### DIFF
--- a/src/Symfony/Configuration.php
+++ b/src/Symfony/Configuration.php
@@ -2,14 +2,21 @@
 
 namespace PHPStan\Symfony;
 
+/**
+ * @phpstan-type ParametersArray array{
+ *     containerXmlPath?: string, container_xml_path?: string,
+ *     constantHassers?: bool, constant_hassers?: bool,
+ *     consoleApplicationLoader?: string, console_application_loader?: string,
+ * }
+ */
 final class Configuration
 {
 
-	/** @var array<string, mixed> */
+	/** @var ParametersArray */
 	private $parameters;
 
 	/**
-	 * @param array<string, mixed> $parameters
+	 * @phpstan-param ParametersArray $parameters
 	 */
 	public function __construct(array $parameters)
 	{

--- a/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
@@ -163,6 +163,7 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 					/** @var ConstantStringType $keyType */
 					$keyType = $scope->getTypeFromValue($key);
 					$keyTypes[] = $keyType;
+					/** @var array<mixed>|bool|float|int|string $element */
 					$valueTypes[] = $this->generalizeTypeFromValue($scope, $element);
 				}
 
@@ -171,9 +172,11 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 
 			return new ArrayType(
 				TypeCombinator::union(...array_map(function ($item) use ($scope): Type {
+					/** @var array<mixed>|bool|float|int|string $item */
 					return $this->generalizeTypeFromValue($scope, $item);
 				}, array_keys($value))),
 				TypeCombinator::union(...array_map(function ($item) use ($scope): Type {
+					/** @var array<mixed>|bool|float|int|string $item */
 					return $this->generalizeTypeFromValue($scope, $item);
 				}, array_values($value)))
 			);

--- a/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
@@ -159,11 +159,11 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 			if ($hasOnlyStringKey) {
 				$keyTypes = [];
 				$valueTypes = [];
+				/** @var array<mixed>|bool|float|int|string $element */
 				foreach ($value as $key => $element) {
 					/** @var ConstantStringType $keyType */
 					$keyType = $scope->getTypeFromValue($key);
 					$keyTypes[] = $keyType;
-					/** @var array<mixed>|bool|float|int|string $element */
 					$valueTypes[] = $this->generalizeTypeFromValue($scope, $element);
 				}
 


### PR DESCRIPTION
Fixed some errors on PHPStan level 9.

As Is:

```
❯ vendor/bin/phpstan analyse src --level 9
Note: Using configuration file /Users/siketyan/.local/src/github.com/phpstan/phpstan-symfony/phpstan.neon.
 54/54 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   Symfony/Configuration.php                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------ 
  21     Method PHPStan\Symfony\Configuration::getContainerXmlPath() should return string|null but returns mixed.          
  26     Method PHPStan\Symfony\Configuration::hasConstantHassers() should return bool but returns mixed.                  
  31     Method PHPStan\Symfony\Configuration::getConsoleApplicationLoader() should return string|null but returns mixed.  
 ------ ------------------------------------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Type/Symfony/ParameterDynamicReturnTypeExtension.php                                                                                                                 
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  166    Parameter #2 $value of method PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension::generalizeTypeFromValue() expects array|bool|float|int|string, mixed given.  
  177    Parameter #2 $value of method PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension::generalizeTypeFromValue() expects array|bool|float|int|string, mixed given.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 5 errors                                                                                                 
                                                                                                                        
```

To Be:

```
❯ vendor/bin/phpstan analyse src --level 9
Note: Using configuration file /Users/siketyan/.local/src/github.com/phpstan/phpstan-symfony/phpstan.neon.
 54/54 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%


                                                                                                                        
 [OK] No errors                                                                                                         

```