### PR TITLE
Allow service subscriber to have non-service name keys under certain circumstances.

### DIFF
--- a/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
@@ -89,8 +89,14 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 	{
 		$scopeClassReflection = $scope->getClassReflection();
 		return $scopeClassReflection !== null &&
-			$scopeClassReflection->implementsInterface('Symfony\Contracts\Service\ServiceSubscriberInterface') &&
-			($isContainerType->yes() || $isPsrContainerType->yes());
+			(
+				$scopeClassReflection->implementsInterface('Symfony\Contracts\Service\ServiceSubscriberInterface') ||
+				$scopeClassReflection->implementsInterface('Symfony\Component\DependencyInjection\ServiceSubscriberInterface')
+			) &&
+			(
+				$isContainerType->yes() ||
+				$isPsrContainerType->yes()
+			);
 	}
 
 }

--- a/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
@@ -9,6 +9,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Symfony\ServiceMap;
+use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Symfony\Helper;
 use function sprintf;
@@ -72,12 +73,24 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
 			$serviceIdType = $scope->getType($node->getArgs()[0]->value);
-			if ($service === null && !$scope->getType(Helper::createMarkerNode($node->var, $serviceIdType, $this->printer))->equals($serviceIdType)) {
+			if (
+				$service === null &&
+				!$this->isContainerCallInServiceSubscriber($isContainerType, $isPsrContainerType, $scope) &&
+				!$scope->getType(Helper::createMarkerNode($node->var, $serviceIdType, $this->printer))->equals($serviceIdType)
+				) {
 				return [sprintf('Service "%s" is not registered in the container.', $serviceId)];
 			}
 		}
 
 		return [];
+	}
+
+	private function isContainerCallInServiceSubscriber(TrinaryLogic $isContainerType, TrinaryLogic $isPsrContainerType, Scope $scope): bool
+	{
+		$scopeClassReflection = $scope->getClassReflection();
+		return $scopeClassReflection !== null &&
+			$scopeClassReflection->implementsInterface('Symfony\Contracts\Service\ServiceSubscriberInterface') &&
+			($isContainerType->yes() || $isPsrContainerType->yes());
 	}
 
 }

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -86,6 +86,20 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testGetPrivateServiceInLegacyServiceSubscriberWithAnotherKey(): void
+	{
+		if (!interface_exists('Symfony\Component\DependencyInjection\ServiceSubscriberInterface')) {
+			self::markTestSkipped('The test needs Symfony\Component\DependencyInjection\ServiceSubscriberInterface class.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleLegacyServiceSubscriberWithLocatorKey.php',
+			],
+			[]
+		);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -41,8 +41,8 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 
 	public function testGetPrivateServiceInAbstractController(): void
 	{
-		if (!class_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller')) {
-			self::markTestSkipped();
+		if (!class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
+			self::markTestSkipped('The test needs Symfony\Bundle\FrameworkBundle\Controller\AbstractController class.');
 		}
 
 		$this->analyse(
@@ -58,7 +58,7 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		);
 	}
 
-	public function testGetPrivateServiceInLegacyServiceSubscriber(): void
+	public function testGetPrivateServiceInServiceSubscriber(): void
 	{
 		if (!interface_exists('Symfony\Contracts\Service\ServiceSubscriberInterface')) {
 			self::markTestSkipped('The test needs Symfony\Contracts\Service\ServiceSubscriberInterface class.');

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -72,6 +72,20 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testGetPrivateServiceInServiceSubscriberWithAnotherKey(): void
+	{
+		if (!interface_exists('Symfony\Contracts\Service\ServiceSubscriberInterface')) {
+			self::markTestSkipped('The test needs Symfony\Contracts\Service\ServiceSubscriberInterface class.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleServiceSubscriberWithLocatorKey.php',
+			],
+			[]
+		);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Rules/Symfony/ExampleLegacyServiceSubscriberWithLocatorKey.php
+++ b/tests/Rules/Symfony/ExampleLegacyServiceSubscriberWithLocatorKey.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ServiceSubscriberInterface;
+
+final class ExampleLegacyServiceSubscriberWithLocatorKey implements ServiceSubscriberInterface
+{
+
+	/** @var ContainerInterface */
+	private $locator;
+
+	public function __construct(ContainerInterface $locator)
+	{
+		$this->locator = $locator;
+	}
+
+	public function privateAliasService(): void
+	{
+		$this->locator->get('private_alias');
+	}
+
+	public function publicAliasService(): void
+	{
+		$this->locator->get('public_alias');
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getSubscribedServices(): array
+	{
+		return [];
+	}
+
+}

--- a/tests/Rules/Symfony/ExampleServiceSubscriberWithLocatorKey.php
+++ b/tests/Rules/Symfony/ExampleServiceSubscriberWithLocatorKey.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use function PHPStan\Rules\Symfony\doFoo;
+
+final class ExampleServiceSubscriberWithLocatorKey implements ServiceSubscriberInterface
+{
+
+	/** @var ContainerInterface */
+	private $locator;
+
+	public function __construct(ContainerInterface $locator)
+	{
+		$this->locator = $locator;
+	}
+
+	public function privateService(): void
+	{
+		$this->locator->get('foobar');
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public static function getSubscribedServices(): array
+	{
+		return [];
+	}
+
+}

--- a/tests/Rules/Symfony/ExampleServiceSubscriberWithLocatorKey.php
+++ b/tests/Rules/Symfony/ExampleServiceSubscriberWithLocatorKey.php
@@ -3,9 +3,7 @@
 namespace PHPStan\Rules\Symfony;
 
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
 use Symfony\Contracts\Service\ServiceSubscriberInterface;
-use function PHPStan\Rules\Symfony\doFoo;
 
 final class ExampleServiceSubscriberWithLocatorKey implements ServiceSubscriberInterface
 {
@@ -18,9 +16,14 @@ final class ExampleServiceSubscriberWithLocatorKey implements ServiceSubscriberI
 		$this->locator = $locator;
 	}
 
-	public function privateService(): void
+	public function privateAliasService(): void
 	{
-		$this->locator->get('foobar');
+		$this->locator->get('private_alias');
+	}
+
+	public function publicAliasService(): void
+	{
+		$this->locator->get('public_alias');
 	}
 
 	/**

--- a/tests/Rules/Symfony/container.xml
+++ b/tests/Rules/Symfony/container.xml
@@ -8,5 +8,10 @@
                 <argument key="private" type="service" id="private"/>
             </argument>
         </service>
+        <service id="service_locator_with_key" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
+            <argument type="collection">
+                <argument key="foobar" type="service" id="private"/>
+            </argument>
+        </service>
     </services>
 </container>

--- a/tests/Rules/Symfony/container.xml
+++ b/tests/Rules/Symfony/container.xml
@@ -8,9 +8,10 @@
                 <argument key="private" type="service" id="private"/>
             </argument>
         </service>
-        <service id="service_locator_with_key" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
+        <service id="service_locator_with_alias_key" class="Symfony\Component\DependencyInjection\ServiceLocator" public="true">
             <argument type="collection">
-                <argument key="foobar" type="service" id="private"/>
+                <argument key="private_alias" type="service" id="private"/>
+                <argument key="public_alias" type="service" id="public"/>
             </argument>
         </service>
     </services>


### PR DESCRIPTION
You can define service subscribers with non-service name keys, e.g. 

```php
class SubmissionStrategyFactory implements ServiceSubscriberInterface
{
    public function __construct(private readonly ContainerInterface $locator)
    {
    }

    public function getStrategy(IllustrationSubmission $submission): SubmissionStrategyInterface
    {
        if ($submission->getIllustrationFile()) {
            return $this->locator->get('upload');
        }

        return $this->locator->get('url');
    }

    public static function getSubscribedServices(): iterable
    {
        yield 'upload' => UploadStrategy::class;
        yield 'url' => UrlStrategy::class;
    }
}
```

phpstan currently reports this as `Service "upload" is not registered in the container.`

This PR allows non-service argument names when the argument is a container and its called within a ServiceLocator.

Maybe, this is also related to #89