### PR TITLE
Extend Serializer stubs

### DIFF
--- a/stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Encoder/DecoderInterface.stub
@@ -18,7 +18,8 @@ interface DecoderInterface
 
     /**
      * @param string $format Format name
+     * @param array<mixed> $context
      * @return bool
      */
-    public function supportsDecoding($format);
+    public function supportsDecoding($format, array $context = []);
 }

--- a/stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Encoder/EncoderInterface.stub
@@ -18,7 +18,8 @@ interface EncoderInterface
 
     /**
      * @param string $format Format name
+     * @param array<mixed> $context
      * @return bool
      */
-    public function supportsEncoding($format);
+    public function supportsEncoding($format, array $context = []);
 }

--- a/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.stub
@@ -33,7 +33,8 @@ interface DenormalizerInterface
      * @param mixed $data
      * @param string $type
      * @param string|null $format
+     * @param array<mixed> $context
      * @return bool
      */
-    public function supportsDenormalization($data, $type, $format = null);
+    public function supportsDenormalization($data, $type, $format = null, array $context = []);
 }

--- a/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
+++ b/stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
@@ -27,7 +27,9 @@ interface NormalizerInterface
     /**
      * @param mixed $data
      * @param string|null $format
+     * @param array<mixed> $context
+     *
      * @return bool
      */
-    public function supportsNormalization($data, $format = null);
+    public function supportsNormalization($data, $format = null, array $context = []);
 }


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/43982, some interfaces from `symfony/serializer` can use an additional `$context` array. This PR extends the stubs, such that everyone can resolve the deprecation messages in their code without manually declaring the type of `$context` 