### PR TITLE
feat: Sync Validor stubs with SF6.1

### DIFF
--- a/stubs/Symfony/Component/Validator/ConstraintViolationInterface.stub
+++ b/stubs/Symfony/Component/Validator/ConstraintViolationInterface.stub
@@ -2,6 +2,9 @@
 
 namespace Symfony\Component\Validator;
 
+/**
+ * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
+ */
 interface ConstraintViolationInterface
 {
 }

--- a/stubs/Symfony/Component/Validator/ConstraintViolationListInterface.stub
+++ b/stubs/Symfony/Component/Validator/ConstraintViolationListInterface.stub
@@ -3,8 +3,11 @@
 namespace Symfony\Component\Validator;
 
 /**
+ * @extends \ArrayAccess<int, ConstraintViolationInterface>
  * @extends \Traversable<int, ConstraintViolationInterface>
+ *
+ * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
-interface ConstraintViolationListInterface extends \Traversable
+interface ConstraintViolationListInterface extends \Traversable, \Countable, \ArrayAccess
 {
 }


### PR DESCRIPTION
Fix for #344

Adding method __toString() to Validator Stubs according to [real Interface](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Validator/ConstraintViolationListInterface.php#L24)

I added some missing part too but I'm not sure if it can break anything in older Symfony / PHP. I can keep it to only adding method if that's needed