### PR TITLE
Fix phpdoc of Twig* callable

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -69,6 +69,9 @@ parameters:
 		- stubs/Symfony/Contracts/Cache/CallbackInterface.stub
 		- stubs/Symfony/Contracts/Cache/ItemInterface.stub
 		- stubs/Twig/Node/Node.stub
+		- stubs/Twig/TwigFilter.stub
+		- stubs/Twig/TwigFunction.stub
+		- stubs/Twig/TwigTest.stub
 
 parametersSchema:
 	symfony: structure([

--- a/stubs/Twig/TwigFilter.stub
+++ b/stubs/Twig/TwigFilter.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Twig;
+
+class TwigFilter
+{
+    /**
+     * @param callable|array<class-string, string>|null $callable
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $name, $callable = null, array $options = [])
+    {
+    }
+}

--- a/stubs/Twig/TwigFunction.stub
+++ b/stubs/Twig/TwigFunction.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Twig;
+
+class TwigFunction
+{
+    /**
+     * @param callable|array<class-string, string>|null $callable
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $name, $callable = null, array $options = [])
+    {
+    }
+}

--- a/stubs/Twig/TwigTest.stub
+++ b/stubs/Twig/TwigTest.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Twig;
+
+class TwigTest
+{
+    /**
+     * @param callable|array<class-string, string>|null $callable
+     * @param array<string, mixed> $options
+     */
+    public function __construct(string $name, $callable = null, array $options = [])
+    {
+    }
+}


### PR DESCRIPTION
This is a Backport of https://github.com/twigphp/Twig/pull/3856

Context can be found here too https://github.com/phpstan/phpstan/discussions/9567

This will solve the issue even if
- symfony does not release a new twig version
- people does not use the latest version (when it's released)