### PR TITLE
Resolve services subscribed to with ServiceSubscriberTrait

### DIFF
--- a/src/Symfony/DefaultServiceMap.php
+++ b/src/Symfony/DefaultServiceMap.php
@@ -2,13 +2,19 @@
 
 namespace PHPStan\Symfony;
 
+use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Name;
+use PhpParser\Node\VariadicPlaceholder;
+use PhpParser\Node\Scalar\MagicConst\Method;
 use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionNamedType;
 use PHPStan\Type\TypeUtils;
 use function count;
 
 final class DefaultServiceMap implements ServiceMap
 {
+	const AUTOWIRE_ATTRIBUTE_CLASS = 'Symfony\Component\DependencyInjection\Attribute\Autowire';
 
 	/** @var ServiceDefinition[] */
 	private $services;
@@ -36,8 +42,118 @@ final class DefaultServiceMap implements ServiceMap
 
 	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
 	{
+		if ($node instanceof Method) {
+			$serviceId = self::getServiceSubscriberId($node, $scope);
+			if (null !== $serviceId) {
+				return $serviceId;
+			}
+		}
+
 		$strings = TypeUtils::getConstantStrings($scope->getType($node));
 		return count($strings) === 1 ? $strings[0]->getValue() : null;
+	}
+
+	private static function getServiceSubscriberId(Expr $node, Scope $scope): ?string
+	{
+		$classReflection = $scope->getClassReflection();
+		$functionName = $scope->getFunctionName();
+		if ($classReflection === null ||
+			$functionName === null ||
+			!$classReflection->hasTraitUse('Symfony\Contracts\Service\ServiceSubscriberTrait')
+		) {
+			return null;
+		}
+
+		$methodReflection = $classReflection->getNativeReflection();
+		$method = $methodReflection->getMethod($functionName);
+		$attributes = $method->getAttributes('Symfony\Contracts\Service\Attribute\SubscribedService');
+		if (count($attributes) !== 1) {
+			return null;
+		}
+
+		$arguments = $attributes[0]->getArgumentsExpressions();
+
+		$autowireArgs = isset($arguments['attributes']) ?
+			self::getAutowireArguments($arguments['attributes'], $scope) :
+			[];
+
+		$value = null;
+		$ignoreValue = false;
+		foreach ($autowireArgs as $key => $arg) {
+			if (!$arg instanceof Arg) {
+				continue;
+			}
+
+			if ($arg->name !== null) {
+				$argName = $arg->name->toString();
+			} elseif ($key === 0) {
+				$argName = 'value';
+			} elseif ($key === 1) {
+				$argName = 'service';
+			} else {
+				continue;
+			}
+
+			// `service` argument overrules others, so break loop
+			$argValue = TypeUtils::getConstantStrings($scope->getType($arg->value));
+			$argValue = count($argValue) === 1 ? $argValue[0]->getValue() : null;
+
+			if (!is_string($argValue)) {
+				continue;
+			}
+
+			if ($argName === 'service') {
+				return $argValue;
+			}
+
+			if ($argName === 'value') {
+				$value = str_starts_with($argValue, '@') &&
+				!str_starts_with($argValue, '@@') &&
+				!str_starts_with($argValue, '@=') ?
+					substr($argValue, 1) :
+					$argValue;
+			} else {
+				// Can't `break` because `service` has higher priority than others
+				$ignoreValue = true;
+			}
+		}
+
+		// If value is provided, and no other arguments with higher priority the value is the service id
+		if (!$ignoreValue && $value !== null) {
+			return $value;
+		}
+
+		$returnType = $method->getReturnType();
+		return $returnType instanceof ReflectionNamedType ? $returnType->getName() : null;
+	}
+
+	/** @return array<Arg|VariadicPlaceholder> */
+	private static function getAutowireArguments(Expr $expression, Scope $scope): array
+	{
+		if ($expression instanceof Expr\New_) {
+			return $expression->class instanceof Name &&
+					$scope->resolveName($expression->class) === self::AUTOWIRE_ATTRIBUTE_CLASS ?
+				$expression->args :
+				[];
+		}
+
+		if ($expression instanceof Expr\Array_) {
+			foreach ($expression->items as $item) {
+				if ($item === null) {
+					continue;
+				}
+
+				$arg = $item->value;
+				if ($arg instanceof Expr\New_) {
+					return $arg->class instanceof Name &&
+							$scope->resolveName($arg->class) === self::AUTOWIRE_ATTRIBUTE_CLASS ?
+						$arg->args :
+						[];
+				}
+			}
+		}
+
+		return [];
 	}
 
 }

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -72,6 +72,41 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testGetPrivateServiceInServiceSubscriberWithTrait(): void
+	{
+		if (!interface_exists('Symfony\Contracts\Service\ServiceSubscriberInterface')) {
+			self::markTestSkipped('The test needs Symfony\Contracts\Service\ServiceSubscriberInterface class.');
+		}
+
+		if (!trait_exists('Symfony\Contracts\Service\ServiceSubscriberTrait')) {
+			self::markTestSkipped('The test needs Symfony\Contracts\Service\ServiceSubscriberTrait class.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleServiceTraitSubscriber.php',
+			],
+			[
+				[
+					'Service "unknown" is not registered in the container.',
+					44,
+				],
+				[
+					'Service "unknown" is not registered in the container.',
+					50,
+				],
+				[
+					'Service "unknown" is not registered in the container.',
+					56,
+				],
+				[
+					'Service "Baz" is not registered in the container.',
+					68,
+				],
+			]
+		);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Rules/Symfony/ExampleServiceTraitSubscriber.php
+++ b/tests/Rules/Symfony/ExampleServiceTraitSubscriber.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Rules\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\Service\Attribute\SubscribedService;
+use Symfony\Contracts\Service\ServiceSubscriberInterface;
+use Symfony\Contracts\Service\ServiceSubscriberTrait;
+
+final class ExampleServiceTraitSubscriber implements ServiceSubscriberInterface
+{
+	use ServiceSubscriberTrait;
+
+	/** @var ContainerInterface */
+	private $locator;
+
+	public function __construct(ContainerInterface $locator)
+	{
+		$this->locator = $locator;
+	}
+
+	#[SubscribedService(attributes: new Autowire('private'))]
+	private function getIndexed(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService(attributes: new Autowire(value: 'private'))]
+	private function getNamedValue(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService(attributes: new Autowire(service: 'private'))]
+	private function getNamedService(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService(attributes: new Autowire('unknown'))]
+	private function getUnknownIndexed(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService(attributes: new Autowire(value: 'unknown'))]
+	private function getUnknownNamedValue(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService(attributes: new Autowire(service: 'unknown'))]
+	private function getUnknownNamedService(): Foo
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService]
+	public function getBar(): \Bar
+	{
+		return $this->locator->get(__METHOD__);
+	}
+
+	#[SubscribedService]
+	public function getBaz(): \Baz
+	{
+		return $this->locator->get(__METHOD__);
+	}
+}

--- a/tests/Rules/Symfony/container.xml
+++ b/tests/Rules/Symfony/container.xml
@@ -8,5 +8,6 @@
                 <argument key="private" type="service" id="private"/>
             </argument>
         </service>
+        <service id="Bar" class="Bar"></service>
     </services>
 </container>


### PR DESCRIPTION
First off I do want to note that I've only looked at PHPStan source code for about a day. So please bear with me, and I'm certain this code can be cleaned up given some tips :)

So, the actual PR: Symfony has the feature of "service subscribers" where a service / class can implement the `ServiceSubscriberInterface` having a `getSubscribedServices` method returning a mapping of desired services / service ids to be injected and their name in the actual container. The DI container will then create a slimmed down container / locator with the requested services. This feature however isn't understood by this extension at all. So when requesting the service `Foo` using the name `Bar` (defined `['Bar' => 'Foo']` in `getSubscribedServices()`, requested as `container->get('Bar')`) this extension will "fail" and falsely report "Service "Bar" is not registered in the container".

To simplify the usage of this interface / mechanism Symfony also contains a trait, `ServiceSubscriberTrait`, which uses some "magic" to implement the `getSubscribedServices()` method. This by scanning all methods in the class, and, in Symfony 6, checking whether they have the `#[SubscribedService]` attribute. In these cases this method will be "mapped" to requesting a service, by using the method name (equaling `__METHOD__`) as service id and the return type as service to request (so `[<__METHOD__> => <return type of method>]`). In Symfony 6 it's also possible to explicitly set the service to request by using `#[SubscribedService(attributes: new Autowire(service: '<service id>'))]` and some variants (`attributes` can be an array, previously a `value` argument was the only argument for `Autowire` which could also explicitly request a service by prefixing it with `@`, obviously arguments can be positional as well, ...).

So what this PR tries to solve is to resolve the service id needed from the "actual" container. This by checking whether the method which calls `->get` / `->has` has this `#[SubscribedService]` attribute and if so it also tries to find whether `Autowired` is provided.

At the moment this PR is still missing some bits, mainly:
* Support for older Symfony versions. For example before Symfony 6 the usage of `#[SubscribedService]` was optional (and previously this attribute didn't even exist). In this case it might / should fallback to checking whether the method calling `->get` / `->has` has no arguments and a type hint defined (and the `->get` / `->has` argument is `__METHOD__`?)
* When `#[SubscribedService]` is used it is possible to use a self defined name instead of `__METHOD__` which I didn't account for at the moment

Further development might be target at actually inspecting `getSubscribedServices` as well. As this most likely will be a constant array (although it might merge with a parent call). But I have no idea whether that is actually possible and how to implement it

Fixes #321