### PR TITLE
Fix phpstan-src build errors

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -336,3 +336,8 @@ services:
 		tags:
 			- phpstan.properties.readWriteExtension
 			- phpstan.additionalConstructorsExtension
+
+	# CacheInterface::get() return type
+	-
+		factory: PHPStan\Type\Symfony\CacheInterfaceGetDynamicReturnTypeExtension
+		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]

--- a/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
@@ -42,6 +42,7 @@ final class CacheInterfaceGetDynamicReturnTypeExtension implements DynamicMethod
 			if ($returnType->isConstantScalarValue()->yes()) {
 				return $returnType->generalize(GeneralizePrecision::lessSpecific());
 			}
+			return $returnType;
 		}
 
 		return null;

--- a/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
@@ -39,10 +39,7 @@ final class CacheInterfaceGetDynamicReturnTypeExtension implements DynamicMethod
 			$returnType = $parametersAcceptor->getReturnType();
 
 			// generalize template parameters
-			if ($returnType->isConstantScalarValue()->yes()) {
-				return $returnType->generalize(GeneralizePrecision::lessSpecific());
-			}
-			return $returnType;
+			return $returnType->generalize(GeneralizePrecision::templateArgument());
 		}
 
 		return null;

--- a/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/CacheInterfaceGetDynamicReturnTypeExtension.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\GeneralizePrecision;
+use PHPStan\Type\Type;
+
+final class CacheInterfaceGetDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Symfony\Contracts\Cache\CacheInterface';
+	}
+
+	public function isMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'get';
+	}
+
+	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+	{
+		if (!isset($methodCall->getArgs()[1])) {
+			return null;
+		}
+
+		$callbackReturnType = $scope->getType($methodCall->getArgs()[1]->value);
+		if ($callbackReturnType->isCallable()->yes()) {
+			$parametersAcceptor = ParametersAcceptorSelector::selectFromArgs(
+				$scope,
+				$methodCall->getArgs(),
+				$callbackReturnType->getCallableParametersAcceptors($scope)
+			);
+			$returnType = $parametersAcceptor->getReturnType();
+
+			// generalize template parameters
+			if ($returnType->isConstantScalarValue()->yes()) {
+				return $returnType->generalize(GeneralizePrecision::lessSpecific());
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/tests/Type/Symfony/data/cache.php
+++ b/tests/Type/Symfony/data/cache.php
@@ -21,6 +21,17 @@ function testNonScalarCacheCallable(\Symfony\Contracts\Cache\CacheInterface $cac
 	assertType('string', $result);
 };
 
+
+/**
+ * @param callable():non-empty-string $fn
+ */
+function testCacheCallableReturnTypeGeneralization(\Symfony\Contracts\Cache\CacheInterface $cache, callable $fn): void {
+	$result = $cache->get('foo', $fn);
+
+	assertType('string', $result);
+};
+
+
 /**
  * @param \Symfony\Contracts\Cache\CallbackInterface<\stdClass> $cb
  */

--- a/tests/Type/Symfony/data/cache.php
+++ b/tests/Type/Symfony/data/cache.php
@@ -13,6 +13,15 @@ function testCacheCallable(\Symfony\Contracts\Cache\CacheInterface  $cache): voi
 };
 
 /**
+ * @param callable():string $fn
+ */
+function testNonScalarCacheCallable(\Symfony\Contracts\Cache\CacheInterface $cache, callable $fn): void {
+	$result = $cache->get('foo', $fn);
+
+	assertType('string', $result);
+};
+
+/**
  * @param \Symfony\Contracts\Cache\CallbackInterface<\stdClass> $cb
  */
  function testCacheCallbackInterface(\Symfony\Contracts\Cache\CacheInterface  $cache, \Symfony\Contracts\Cache\CallbackInterface $cb): void {


### PR DESCRIPTION
before this PR

```
There was 1 failure:

1) PHPStan\Type\Symfony\ExtensionTest::testFileAsserts with data set "/home/runner/work/phpstan-src/phpstan-src/extension/tests/Type/Symfony/data/cache.php:12" ('type', '/home/runner/work/phpstan-src...he.php', PHPStan\Type\Constant\ConstantStringType Object (...), PHPStan\Type\Constant\ConstantStringType Object (...), 12)
Expected type string, got type '' in /home/runner/work/phpstan-src/phpstan-src/extension/tests/Type/Symfony/data/cache.php on line 12.
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-'string'
+''''
```