### PR TITLE
Add documentation to load DI helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ parameters:
     # If you're using PHP config files for Symfony 5.3+, you also need this for auto-loading of `Symfony\Config`:
     scanDirectories:
         - var/cache/dev/Symfony/Config
+    # If you're using PHP config files (including the ones under packages/*.php) for Symfony 5.3+,
+    # you need this to load the helper functions (i.e. service(), env()):
+    scanFiles:
+        - vendor/symfony/dependency-injection/Loader/Configurator/ContainerConfigurator.php
 ```
 
 ## Constant hassers


### PR DESCRIPTION
This re-introduces the documentation removed in https://github.com/phpstan/phpstan-symfony/commit/94e6c34d81ee842d9ace775698c86596aaed3ffc
