### PR TITLE
Add missing `@method` to ConstraintViolationInterface

### DIFF
--- a/stubs/Symfony/Component/Validator/ConstraintViolationInterface.stub
+++ b/stubs/Symfony/Component/Validator/ConstraintViolationInterface.stub
@@ -3,7 +3,9 @@
 namespace Symfony\Component\Validator;
 
 /**
- * @method string __toString() Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
+ * @method Constraint|null getConstraint() Returns the constraint whose validation caused the violation. Not implementing it is deprecated since Symfony 6.3.
+ * @method mixed           getCause()      Returns the cause of the violation. Not implementing it is deprecated since Symfony 6.2.
+ * @method string          __toString()    Converts the violation into a string for debugging purposes. Not implementing it is deprecated since Symfony 6.1.
  */
 interface ConstraintViolationInterface
 {


### PR DESCRIPTION
Not sure it's a wanted behavior, but if the stub does not declare all the `@method` annotation of the original file, method are considered as undefined. So I add them.