### PR TITLE
Add param out for propertyAccessor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.2 || ^8.0",
     "ext-simplexml": "*",
-    "phpstan/phpstan": "^1.10.36"
+    "phpstan/phpstan": "^1.10.62"
   },
   "conflict": {
     "symfony/framework-bundle": "<3.0"

--- a/extension.neon
+++ b/extension.neon
@@ -66,6 +66,7 @@ parameters:
 		- stubs/Symfony/Component/OptionsResolver/Exception/InvalidOptionsException.stub
 		- stubs/Symfony/Component/OptionsResolver/Options.stub
 		- stubs/Symfony/Component/Process/Process.stub
+		- stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
 		- stubs/Symfony/Component/PropertyAccess/PropertyPathInterface.stub
 		- stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub
 		- stubs/Symfony/Component/Security/Acl/Model/EntryInterface.stub

--- a/extension.neon
+++ b/extension.neon
@@ -66,6 +66,11 @@ parameters:
 		- stubs/Symfony/Component/OptionsResolver/Exception/InvalidOptionsException.stub
 		- stubs/Symfony/Component/OptionsResolver/Options.stub
 		- stubs/Symfony/Component/Process/Process.stub
+		- stubs/Symfony/Component/PropertyAccess/Exception/AccessException.stub
+		- stubs/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.stub
+		- stubs/Symfony/Component/PropertyAccess/Exception/InvalidArgumentException.stub
+		- stubs/Symfony/Component/PropertyAccess/Exception/RuntimeException.stub
+		- stubs/Symfony/Component/PropertyAccess/Exception/UnexpectedTypeException.stub
 		- stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
 		- stubs/Symfony/Component/PropertyAccess/PropertyPathInterface.stub
 		- stubs/Symfony/Component/Security/Acl/Model/AclInterface.stub

--- a/stubs/Symfony/Component/PropertyAccess/Exception/AccessException.stub
+++ b/stubs/Symfony/Component/PropertyAccess/Exception/AccessException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Exception;
+
+class AccessException extends RuntimeException
+{
+}

--- a/stubs/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.stub
+++ b/stubs/Symfony/Component/PropertyAccess/Exception/ExceptionInterface.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Exception;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/stubs/Symfony/Component/PropertyAccess/Exception/InvalidArgumentException.stub
+++ b/stubs/Symfony/Component/PropertyAccess/Exception/InvalidArgumentException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/PropertyAccess/Exception/RuntimeException.stub
+++ b/stubs/Symfony/Component/PropertyAccess/Exception/RuntimeException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Exception;
+
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/stubs/Symfony/Component/PropertyAccess/Exception/UnexpectedTypeException.stub
+++ b/stubs/Symfony/Component/PropertyAccess/Exception/UnexpectedTypeException.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess\Exception;
+
+class UnexpectedTypeException extends RuntimeException
+{
+}

--- a/stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
+++ b/stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Component\PropertyAccess;
+
+interface PropertyAccessorInterface
+{
+
+    /**
+     * @phpstan-template T of object|array<mixed>
+     * @phpstan-param T &$objectOrArray
+     * @phpstan-param-out ($objectOrArray is object ? T : array<mixed>) $objectOrArray
+     *
+     * @return void
+     *
+     * @throws Exception\InvalidArgumentException If the property path is invalid
+     * @throws Exception\AccessException          If a property/index does not exist or is not public
+     * @throws Exception\UnexpectedTypeException  If a value within the path is neither object nor array
+     */
+    public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value);
+
+}

--- a/stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
+++ b/stubs/Symfony/Component/PropertyAccess/PropertyAccessorInterface.stub
@@ -9,6 +9,8 @@ interface PropertyAccessorInterface
      * @phpstan-template T of object|array<mixed>
      * @phpstan-param T &$objectOrArray
      * @phpstan-param-out ($objectOrArray is object ? T : array<mixed>) $objectOrArray
+     * @phpstan-param string|PropertyPathInterface $propertyPath
+     * @phpstan-param mixed $value
      *
      * @return void
      *
@@ -16,6 +18,6 @@ interface PropertyAccessorInterface
      * @throws Exception\AccessException          If a property/index does not exist or is not public
      * @throws Exception\UnexpectedTypeException  If a value within the path is neither object nor array
      */
-    public function setValue(object|array &$objectOrArray, string|PropertyPathInterface $propertyPath, mixed $value);
+    public function setValue(&$objectOrArray, $propertyPath, $value);
 
 }

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -28,6 +28,7 @@ class ExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleOptionCommand.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleOptionLazyCommand.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/kernel_interface.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/property_accessor.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/request_get_content.php');
 
 		$ref = new ReflectionMethod(Request::class, 'getSession');

--- a/tests/Type/Symfony/data/property_accessor.php
+++ b/tests/Type/Symfony/data/property_accessor.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types = 1);
+
+use function PHPStan\Testing\assertType;
+
+$propertyAccessor = new \Symfony\Component\PropertyAccess\PropertyAccessor();
+
+$array = [1 => 'ea'];
+$propertyAccessor->setValue($array, 'foo', 'bar');
+assertType('array', $array);
+
+$object = new \stdClass();
+$propertyAccessor->setValue($object, 'foo', 'bar');
+assertType('stdClass', $object);


### PR DESCRIPTION
When setting value to an object the object type does not change.

When setting value to an object, the array values change. But at least we know it's an array and not `array|object`.