### PR TITLE
Add stub for Compound::getConstraints()

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -96,6 +96,8 @@ parameters:
 		- stubs/Symfony/Component/Serializer/Normalizer/NormalizableInterface.stub
 		- stubs/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub
 		- stubs/Symfony/Component/Validator/Constraint.stub
+		- stubs/Symfony/Component/Validator/Constraints/Composite.stub
+		- stubs/Symfony/Component/Validator/Constraints/Compound.stub
 		- stubs/Symfony/Component/Validator/ConstraintViolationInterface.stub
 		- stubs/Symfony/Component/Validator/ConstraintViolationListInterface.stub
 		- stubs/Symfony/Contracts/Cache/CacheInterface.stub

--- a/stubs/Symfony/Component/Validator/Constraints/Composite.stub
+++ b/stubs/Symfony/Component/Validator/Constraints/Composite.stub
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+abstract class Composite extends Constraint
+{
+}

--- a/stubs/Symfony/Component/Validator/Constraints/Compound.stub
+++ b/stubs/Symfony/Component/Validator/Constraints/Compound.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+abstract class Compound extends Composite
+{
+    /**
+     * @param array<mixed> $options
+     * @return array<Constraint>
+     */
+    abstract protected function getConstraints(array $options): array;
+}


### PR DESCRIPTION
This PR fixes a error people get when implementing compound constraints:

> Method App\Validator\Constraints\MyConstraint::getConstraints() has parameter $options with no value type specified in iterable type array.

Symfony does not document the structure of the `$options` array, which can be an array of anything.