### PR TITLE
Synchronize Compound::getConstraints() with Symfony phpdoc

### DIFF
--- a/stubs/Symfony/Component/Validator/Constraints/Compound.stub
+++ b/stubs/Symfony/Component/Validator/Constraints/Compound.stub
@@ -7,7 +7,7 @@ use Symfony\Component\Validator\Constraint;
 abstract class Compound extends Composite
 {
     /**
-     * @param array<mixed> $options
+     * @param array<string, mixed> $options
      * @return array<Constraint>
      */
     abstract protected function getConstraints(array $options): array;


### PR DESCRIPTION
Pr https://github.com/symfony/symfony/pull/54574 was accepted.

Which means the phpdoc should be `array<string, mixed>` and not `array<mixed>`
https://github.com/symfony/symfony/pull/54574/files#diff-bb41b84020d311b1a23f6a18724be831e6d9789dd44dc29ed024cbe13ae1a6b1R49