### PR TITLE
make creation of ServiceMap and ParameterMap lazy

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -128,14 +128,14 @@ services:
 		class: PHPStan\Symfony\ServiceMapFactory
 		factory: PHPStan\Symfony\XmlServiceMapFactory
 	-
-		factory: @symfony.serviceMapFactory::create()
+		factory: PHPStan\Symfony\LazyServiceMap
 
 	# parameter map
 	symfony.parameterMapFactory:
 		class: PHPStan\Symfony\ParameterMapFactory
 		factory: PHPStan\Symfony\XmlParameterMapFactory
 	-
-		factory: @symfony.parameterMapFactory::create()
+		factory: PHPStan\Symfony\LazyParameterMap
 
 	# ControllerTrait::get()/has() return type
 	-

--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -65,7 +65,7 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 			return [];
 		}
 
-		$serviceId = $this->serviceMap::getServiceIdFromNode($node->getArgs()[0]->value, $scope);
+		$serviceId = $this->serviceMap->getServiceIdFromNode($node->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
 			if ($service !== null && !$service->isPublic()) {

--- a/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
@@ -65,7 +65,7 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 			return [];
 		}
 
-		$serviceId = $this->serviceMap::getServiceIdFromNode($node->getArgs()[0]->value, $scope);
+		$serviceId = $this->serviceMap->getServiceIdFromNode($node->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
 			$serviceIdType = $scope->getType($node->getArgs()[0]->value);

--- a/src/Symfony/DefaultParameterMap.php
+++ b/src/Symfony/DefaultParameterMap.php
@@ -35,7 +35,7 @@ final class DefaultParameterMap implements ParameterMap
 		return $this->parameters[$key] ?? null;
 	}
 
-	public static function getParameterKeysFromNode(Expr $node, Scope $scope): array
+	public function getParameterKeysFromNode(Expr $node, Scope $scope): array
 	{
 		$strings = TypeUtils::getConstantStrings($scope->getType($node));
 

--- a/src/Symfony/DefaultServiceMap.php
+++ b/src/Symfony/DefaultServiceMap.php
@@ -34,7 +34,7 @@ final class DefaultServiceMap implements ServiceMap
 		return $this->services[$id] ?? null;
 	}
 
-	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
+	public function getServiceIdFromNode(Expr $node, Scope $scope): ?string
 	{
 		$strings = TypeUtils::getConstantStrings($scope->getType($node));
 		return count($strings) === 1 ? $strings[0]->getValue() : null;

--- a/src/Symfony/FakeParameterMap.php
+++ b/src/Symfony/FakeParameterMap.php
@@ -21,7 +21,7 @@ final class FakeParameterMap implements ParameterMap
 		return null;
 	}
 
-	public static function getParameterKeysFromNode(Expr $node, Scope $scope): array
+	public function getParameterKeysFromNode(Expr $node, Scope $scope): array
 	{
 		return [];
 	}

--- a/src/Symfony/FakeServiceMap.php
+++ b/src/Symfony/FakeServiceMap.php
@@ -21,7 +21,7 @@ final class FakeServiceMap implements ServiceMap
 		return null;
 	}
 
-	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string
+	public function getServiceIdFromNode(Expr $node, Scope $scope): ?string
 	{
 		return null;
 	}

--- a/src/Symfony/LazyParameterMap.php
+++ b/src/Symfony/LazyParameterMap.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+
+class LazyParameterMap implements ParameterMap
+{
+
+	private ParameterMapFactory $factory;
+
+	private ?ParameterMap $parameterMap = null;
+
+	public function __construct(ParameterMapFactory $factory)
+	{
+		$this->factory = $factory;
+	}
+
+	public function getParameters(): array
+	{
+		return ($this->parameterMap ??= $this->factory->create())->getParameters();
+	}
+
+	public function getParameter(string $key): ?ParameterDefinition
+	{
+		return ($this->parameterMap ??= $this->factory->create())->getParameter($key);
+	}
+
+	public function getParameterKeysFromNode(Expr $node, Scope $scope): array
+	{
+		return ($this->parameterMap ??= $this->factory->create())->getParameterKeysFromNode($node, $scope);
+	}
+
+}

--- a/src/Symfony/LazyServiceMap.php
+++ b/src/Symfony/LazyServiceMap.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PhpParser\Node\Expr;
+use PHPStan\Analyser\Scope;
+
+class LazyServiceMap implements ServiceMap
+{
+
+	private ServiceMapFactory $factory;
+
+	private ?ServiceMap $serviceMap = null;
+
+	public function __construct(ServiceMapFactory $factory)
+	{
+		$this->factory = $factory;
+	}
+
+	public function getServices(): array
+	{
+		return ($this->serviceMap ??= $this->factory->create())->getServices();
+	}
+
+	public function getService(string $id): ?ServiceDefinition
+	{
+		return ($this->serviceMap ??= $this->factory->create())->getService($id);
+	}
+
+	public function getServiceIdFromNode(Expr $node, Scope $scope): ?string
+	{
+		return ($this->serviceMap ??= $this->factory->create())->getServiceIdFromNode($node, $scope);
+	}
+
+}

--- a/src/Symfony/ParameterMap.php
+++ b/src/Symfony/ParameterMap.php
@@ -18,6 +18,6 @@ interface ParameterMap
 	/**
 	 * @return array<string>
 	 */
-	public static function getParameterKeysFromNode(Expr $node, Scope $scope): array;
+	public function getParameterKeysFromNode(Expr $node, Scope $scope): array;
 
 }

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -15,6 +15,6 @@ interface ServiceMap
 
 	public function getService(string $id): ?ServiceDefinition;
 
-	public static function getServiceIdFromNode(Expr $node, Scope $scope): ?string;
+	public function getServiceIdFromNode(Expr $node, Scope $scope): ?string;
 
 }

--- a/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
@@ -123,7 +123,7 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 			return $defaultReturnType;
 		}
 
-		$parameterKeys = $this->parameterMap::getParameterKeysFromNode($methodCall->getArgs()[0]->value, $scope);
+		$parameterKeys = $this->parameterMap->getParameterKeysFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($parameterKeys === []) {
 			return $defaultReturnType;
 		}
@@ -222,7 +222,7 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 			return $defaultReturnType;
 		}
 
-		$parameterKeys = $this->parameterMap::getParameterKeysFromNode($methodCall->getArgs()[0]->value, $scope);
+		$parameterKeys = $this->parameterMap->getParameterKeysFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($parameterKeys === []) {
 			return $defaultReturnType;
 		}

--- a/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
@@ -88,7 +88,7 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 			return $returnType;
 		}
 
-		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
+		$serviceId = $this->serviceMap->getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
 			if ($service !== null && (!$service->isSynthetic() || $service->getClass() !== null)) {
@@ -134,7 +134,7 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 			return $returnType;
 		}
 
-		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
+		$serviceId = $this->serviceMap->getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);
 			return new ConstantBooleanType($service !== null && $service->isPublic());


### PR DESCRIPTION
Currently one can not use PHPStans `bootstrapFiles` to create the container (dump) which could then be ready by
`symfony.containerXmlPath`. This as the order of initialization results in the `XmlServiceMapFactory` / `XmlParameterMapFactory` `create` methods being called before the `bootstrapFiles` are executed. By making the `ServiceMap` / `ParameterMap` lazy these will only be created when actually used, which is after the `bootstrapFiles` have been executed.