### PR TITLE
Update getArgument return type in interact method

### DIFF
--- a/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
@@ -10,6 +10,7 @@ use PHPStan\Symfony\ConsoleApplicationResolver;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\IntegerType;
+use PHPStan\Type\NullType;
 use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
@@ -74,6 +75,11 @@ final class InputInterfaceGetArgumentDynamicReturnTypeExtension implements Dynam
 			} catch (InvalidArgumentException $e) {
 				// noop
 			}
+		}
+
+		$method = $scope->getFunction();
+		if ($method instanceof MethodReflection && $method->getName() === 'interact') {
+			$argTypes[] = new NullType();
 		}
 
 		return count($argTypes) > 0 ? TypeCombinator::union(...$argTypes) : null;

--- a/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
@@ -16,6 +16,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\TypeUtils;
 use function count;
+use function in_array;
 
 final class InputInterfaceGetArgumentDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -78,7 +79,11 @@ final class InputInterfaceGetArgumentDynamicReturnTypeExtension implements Dynam
 		}
 
 		$method = $scope->getFunction();
-		if ($method instanceof MethodReflection && $method->getName() === 'interact') {
+		if (
+			$method instanceof MethodReflection
+			&& $method->getName() === 'interact'
+			&& in_array('Symfony\Component\Console\Command\Command', $method->getDeclaringClass()->getParentClassesNames(), true)
+		) {
 			$argTypes[] = new NullType();
 		}
 

--- a/tests/Type/Symfony/data/ExampleBaseCommand.php
+++ b/tests/Type/Symfony/data/ExampleBaseCommand.php
@@ -17,6 +17,17 @@ abstract class ExampleBaseCommand extends Command
 		$this->addArgument('base');
 	}
 
+	protected function interact(InputInterface $input, OutputInterface $output): int
+	{
+		assertType('string|null', $input->getArgument('base'));
+		assertType('string|null', $input->getArgument('aaa'));
+		assertType('string|null', $input->getArgument('bbb'));
+		assertType('array<int, string>|string|null', $input->getArgument('diff'));
+		assertType('array<int, string>|null', $input->getArgument('arr'));
+		assertType('string|null', $input->getArgument('both'));
+		assertType('Symfony\Component\Console\Helper\QuestionHelper', $this->getHelper('question'));
+	}
+
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
 		assertType('string|null', $input->getArgument('base'));


### PR DESCRIPTION
Solve https://github.com/phpstan/phpstan-symfony/issues/256 (cc @alexander-schranz)

By design, all the arguments can be null in Command::interact method.
Doing
```
/** @var string|null $market */
$market = $input->getArgument('market');
```
in the interact method is reported as an error by PHPStan so there is currently no satisfying solution except ignoring the error. And updating the dynamic return type extension seems doable.