### PR TITLE
Add DefinitionConfigurator stub for rootNode ArrayNodeDefinition return type

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -32,6 +32,7 @@ parameters:
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
 		- stubs/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.stub
 		- stubs/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FirewallListenerFactoryInterface.stub
+		- stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
 		- stubs/Symfony/Component/Console/Command.stub
 		- stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub
 		- stubs/Symfony/Component/Console/Exception/InvalidArgumentException.stub

--- a/extension.neon
+++ b/extension.neon
@@ -32,6 +32,7 @@ parameters:
 		- stubs/Symfony/Bundle/FrameworkBundle/Test/TestContainer.stub
 		- stubs/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AuthenticatorFactoryInterface.stub
 		- stubs/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FirewallListenerFactoryInterface.stub
+		- stubs/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.stub
 		- stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
 		- stubs/Symfony/Component/Console/Command.stub
 		- stubs/Symfony/Component/Console/Exception/ExceptionInterface.stub

--- a/stubs/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.stub
+++ b/stubs/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace Symfony\Component\Config\Definition\Builder;
+
+class ArrayNodeDefinition
+{
+
+}

--- a/stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
+++ b/stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symfony\Component\Config\Definition\Configurator;
+
+class DefinitionConfigurator
+{
+    /**
+     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     */
+    public function rootNode();
+}

--- a/stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
+++ b/stubs/Symfony/Component/Config/Definition/Configurator/DefinitionConfigurator.stub
@@ -2,10 +2,14 @@
 
 namespace Symfony\Component\Config\Definition\Configurator;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+
 class DefinitionConfigurator
 {
+
     /**
-     * @return \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition
+     * @return ArrayNodeDefinition
      */
     public function rootNode();
+
 }

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -67,6 +67,12 @@ class ExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor/WithConfigurationWithConstructorExtension.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor-optional-params/WithConfigurationWithConstructorOptionalParamsExtension.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor-required-params/WithConfigurationWithConstructorRequiredParamsExtension.php');
+
+		if (!class_exists('Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator')) {
+			return;
+		}
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/definition_configurator.php');
 	}
 
 	/**

--- a/tests/Type/Symfony/data/definition_configurator.php
+++ b/tests/Type/Symfony/data/definition_configurator.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;
+use Symfony\Component\Config\Definition\Loader\DefinitionFileLoader;
+use function PHPStan\Testing\assertType;
+
+$treeBuilder = new TreeBuilder('my_tree');
+$loader = new DefinitionFileLoader($treeBuilder, new \Symfony\Component\Config\FileLocator());
+
+$configurator = new DefinitionConfigurator(
+	$treeBuilder,
+	$loader,
+	'',
+	''
+);
+
+$rootNode = $configurator->rootNode();
+assertType('Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition', $rootNode);


### PR DESCRIPTION
Fixes #278 

The DefinitionConfigurator::rootNode method always returns an ArrayNodeDefinition, but without this PR when we use this code:

```php
use Symfony\Component\Config\Definition\Configurator\DefinitionConfigurator;

class ExampleBundle extends AbstractBundle
{
    public function configure(DefinitionConfigurator $definition): void
    {
        $definition->rootNode()
            ->children()
            ->end()
        ;
    }
```

We get the following error:

```
Call to an undefined method Symfony\Component\Config\Definition\Builder\NodeDefinition::children().
```