### PR TITLE
Support for alias to inlined service

### DIFF
--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -48,11 +48,11 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 			}
 
 			$service = new Service(
-				strpos((string) $attrs->id, '.') === 0 ? substr((string) $attrs->id, 1) : (string) $attrs->id,
+				$this->cleanServiceId((string) $attrs->id),
 				isset($attrs->class) ? (string) $attrs->class : null,
 				isset($attrs->public) && (string) $attrs->public === 'true',
 				isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
-				isset($attrs->alias) ? (string) $attrs->alias : null
+				isset($attrs->alias) ? $this->cleanServiceId((string) $attrs->alias) : null
 			);
 
 			if ($service->getAlias() !== null) {
@@ -77,6 +77,11 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 		}
 
 		return new DefaultServiceMap($services);
+	}
+
+	private function cleanServiceId(string $id): string
+	{
+		return strpos($id, '.') === 0 ? substr($id, 1) : $id;
 	}
 
 }

--- a/tests/Symfony/DefaultServiceMapTest.php
+++ b/tests/Symfony/DefaultServiceMapTest.php
@@ -113,6 +113,17 @@ final class DefaultServiceMapTest extends TestCase
 				self::assertSame('withClass', $service->getAlias());
 			},
 		];
+		yield [
+			'aliasForInlined',
+			static function (?Service $service): void {
+				self::assertNotNull($service);
+				self::assertSame('aliasForInlined', $service->getId());
+				self::assertNull($service->getClass());
+				self::assertFalse($service->isPublic());
+				self::assertFalse($service->isSynthetic());
+				self::assertSame('inlined', $service->getAlias());
+			},
+		];
 	}
 
 }

--- a/tests/Symfony/container.xml
+++ b/tests/Symfony/container.xml
@@ -41,5 +41,7 @@
     <service id="public" class="Foo" public="true"></service>
     <service id="synthetic" class="Foo" synthetic="true"></service>
     <service id="alias" class="Bar" alias="withClass"></service>
+    <service id=".inlined"></service>
+    <service id="aliasForInlined" alias=".inlined"></service>
   </services>
 </container>


### PR DESCRIPTION
# Why
When [stacking decorators](https://symfony.com/doc/current/service_container/service_decoration.html#stacking-decorators), all inlined services are prefixed by a `.`. This character is explicitly removed in the service map since [this commit](https://github.com/phpstan/phpstan-symfony/commit/74da071c10482f509dcb443e26fb52a4e9511556).

But then, when browsing aliases, the Xml factory is not able to find the target service in the map, because the alias definition contains the `.`, but not the stored service. The we got following false-positive 
```
Service "<...>" is not registered in the container.
```

# How
I added the same log for `alias` field that the one for `id`, and it fixed the issue locally. I added a test for this use case.

⚠️ I'm not sure why this `.` has been removed in first place, maybe there are other (untested?) side-effects... at least the discussion is opened 🙂 

Thanks a lot for your work 🙇 