### PR TITLE
Improve Command::initialize and `command` argument inferences

### DIFF
--- a/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputInterfaceGetArgumentDynamicReturnTypeExtension.php
@@ -89,7 +89,7 @@ final class InputInterfaceGetArgumentDynamicReturnTypeExtension implements Dynam
 		if (
 			$canBeNullInInteract
 			&& $method instanceof MethodReflection
-			&& $method->getName() === 'interact'
+			&& ($method->getName() === 'interact' || $method->getName() === 'initialize')
 			&& in_array('Symfony\Component\Console\Command\Command', $method->getDeclaringClass()->getParentClassesNames(), true)
 		) {
 			$argTypes[] = new NullType();

--- a/src/Type/Symfony/InputInterfaceHasArgumentDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/InputInterfaceHasArgumentDynamicReturnTypeExtension.php
@@ -13,6 +13,7 @@ use PHPStan\Type\Type;
 use PHPStan\Type\TypeUtils;
 use function array_unique;
 use function count;
+use function in_array;
 
 final class InputInterfaceHasArgumentDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -51,6 +52,17 @@ final class InputInterfaceHasArgumentDynamicReturnTypeExtension implements Dynam
 			return null;
 		}
 		$argName = $argStrings[0]->getValue();
+
+		if ($argName === 'command') {
+			$method = $scope->getFunction();
+			if (
+				$method instanceof MethodReflection
+				&& ($method->getName() === 'interact' || $method->getName() === 'initialize')
+				&& in_array('Symfony\Component\Console\Command\Command', $method->getDeclaringClass()->getParentClassesNames(), true)
+			) {
+				return null;
+			}
+		}
 
 		$returnTypes = [];
 		foreach ($this->consoleApplicationResolver->findCommands($classReflection) as $command) {

--- a/tests/Type/Symfony/data/ExampleBaseCommand.php
+++ b/tests/Type/Symfony/data/ExampleBaseCommand.php
@@ -19,8 +19,26 @@ abstract class ExampleBaseCommand extends Command
 		$this->addArgument('base');
 	}
 
-	protected function interact(InputInterface $input, OutputInterface $output): int
+	protected function initialize(InputInterface $input, OutputInterface $output): void
 	{
+		assertType('bool', $input->hasArgument('command'));
+		assertType('string|null', $input->getArgument('command'));
+
+		assertType('string|null', $input->getArgument('base'));
+		assertType('string', $input->getArgument('aaa'));
+		assertType('string', $input->getArgument('bbb'));
+		assertType('string|null', $input->getArgument('required'));
+		assertType('array<int, string>|string', $input->getArgument('diff'));
+		assertType('array<int, string>', $input->getArgument('arr'));
+		assertType('string|null', $input->getArgument('both'));
+		assertType('Symfony\Component\Console\Helper\QuestionHelper', $this->getHelper('question'));
+	}
+
+	protected function interact(InputInterface $input, OutputInterface $output): void
+	{
+		assertType('bool', $input->hasArgument('command'));
+		assertType('string|null', $input->getArgument('command'));
+
 		assertType('string|null', $input->getArgument('base'));
 		assertType('string', $input->getArgument('aaa'));
 		assertType('string', $input->getArgument('bbb'));
@@ -33,6 +51,9 @@ abstract class ExampleBaseCommand extends Command
 
 	protected function execute(InputInterface $input, OutputInterface $output): int
 	{
+		assertType('true', $input->hasArgument('command'));
+		assertType('string', $input->getArgument('command'));
+
 		assertType('string|null', $input->getArgument('base'));
 		assertType('string', $input->getArgument('aaa'));
 		assertType('string', $input->getArgument('bbb'));


### PR DESCRIPTION
This follow the same idea of https://github.com/phpstan/phpstan-symfony/pull/391.

When looking at the execute method of the Symfony command
https://github.com/symfony/symfony/blob/c0e30bb06bb4c12efc8bad13f7cb732954cb0182/src/Symfony/Component/Console/Command/Command.php#L231-L280

The order of the call are
```
$this->initialize($input, $output);
$this->interact($input, $output);
if ($input->hasArgument('command') && null === $input->getArgument('command')) {
     $input->setArgument('command', $this->getName());
}
$input->validate();
$this->execute($input, $output);
```

Which means that:
- In the initialize method the `command` argument might be missing
- In the interact method the `command` argument might be missing
- In the initialize method, like in the interact one` option might be missing since they are not yet validated.