### PR TITLE
Fix the KernelTestCase stub

### DIFF
--- a/stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Test/KernelTestCase.stub
@@ -5,11 +5,6 @@ namespace Symfony\Bundle\FrameworkBundle\Test;
 abstract class KernelTestCase
 {
     /**
-     * @var TestContainer
-     */
-    protected static $container;
-
-    /**
      * @return TestContainer
      */
     abstract public function getContainer();


### PR DESCRIPTION
KernelTestCase does not have a `$container` static property