### PR TITLE
Do not use InputBagTypeSpecifyingExtension on true context.

### DIFF
--- a/src/Type/Symfony/InputBagTypeSpecifyingExtension.php
+++ b/src/Type/Symfony/InputBagTypeSpecifyingExtension.php
@@ -30,7 +30,7 @@ final class InputBagTypeSpecifyingExtension implements MethodTypeSpecifyingExten
 
 	public function isMethodSupported(MethodReflection $methodReflection, MethodCall $node, TypeSpecifierContext $context): bool
 	{
-		return $methodReflection->getName() === self::HAS_METHOD_NAME && !$context->null();
+		return $methodReflection->getName() === self::HAS_METHOD_NAME && $context->false();
 	}
 
 	public function specifyTypes(MethodReflection $methodReflection, MethodCall $node, Scope $scope, TypeSpecifierContext $context): SpecifiedTypes

--- a/tests/Type/Symfony/data/input_bag.php
+++ b/tests/Type/Symfony/data/input_bag.php
@@ -7,7 +7,8 @@ $bag = new \Symfony\Component\HttpFoundation\InputBag(['foo' => 'bar', 'bar' => 
 assertType('bool|float|int|string|null', $bag->get('foo'));
 
 if ($bag->has('foo')) {
-	assertType('bool|float|int|string', $bag->get('foo'));
+	// Because `has` rely on `array_key_exists` we can still have set the NULL value.
+	assertType('bool|float|int|string|null', $bag->get('foo'));
 	assertType('bool|float|int|string|null', $bag->get('bar'));
 } else {
 	assertType('null', $bag->get('foo'));


### PR DESCRIPTION
The `InputBag::has` method rely on `array_key_exists`

see
https://github.com/symfony/symfony/blob/e7589c18012314ef262f040357b832a264b2a6eb/src/Symfony/Component/HttpFoundation/ParameterBag.php#L86-L89

So the following code is valid
```
$inputBag->set('foo', null);
$inputBag->has('foo'); // true
$inputBag->get('foo'); // null
```

:/ 