### PR TITLE
feat: Add @api annotation to interfaces

### DIFF
--- a/src/Symfony/ParameterDefinition.php
+++ b/src/Symfony/ParameterDefinition.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Symfony;
 
+/**
+ * @api
+ */
 interface ParameterDefinition
 {
 

--- a/src/Symfony/ParameterMap.php
+++ b/src/Symfony/ParameterMap.php
@@ -5,6 +5,9 @@ namespace PHPStan\Symfony;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 
+/**
+ * @api
+ */
 interface ParameterMap
 {
 

--- a/src/Symfony/ServiceDefinition.php
+++ b/src/Symfony/ServiceDefinition.php
@@ -2,6 +2,9 @@
 
 namespace PHPStan\Symfony;
 
+/**
+ * @api
+ */
 interface ServiceDefinition
 {
 

--- a/src/Symfony/ServiceMap.php
+++ b/src/Symfony/ServiceMap.php
@@ -5,6 +5,9 @@ namespace PHPStan\Symfony;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 
+/**
+ * @api
+ */
 interface ServiceMap
 {
 


### PR DESCRIPTION
The following interfaces are now part of the public API and can be safely relied on.

- \PHPStan\Symfony\ParameterDefinition
- \PHPStan\Symfony\ParameterMap
- \PHPStan\Symfony\ServiceDefinition
- \PHPStan\Symfony\ServiceMap

Changes according to the following discussion: https://github.com/phpstan/phpstan/discussions/11967