### PR TITLE
Support Symfony #[AutowireLocator] attribute

### DIFF
--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -5,12 +5,19 @@ namespace PHPStan\Rules\Symfony;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\BetterReflection\Reflection\Adapter\FakeReflectionAttribute;
+use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Symfony\ServiceDefinition;
 use PHPStan\Symfony\ServiceMap;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use function class_exists;
+use function get_class;
 use function sprintf;
 
 /**
@@ -66,15 +73,29 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		}
 
 		$serviceId = $this->serviceMap::getServiceIdFromNode($node->getArgs()[0]->value, $scope);
-		if ($serviceId !== null) {
-			$service = $this->serviceMap->getService($serviceId);
-			if ($service !== null && !$service->isPublic()) {
-				return [
-					RuleErrorBuilder::message(sprintf('Service "%s" is private.', $serviceId))
-						->identifier('symfonyContainer.privateService')
-						->build(),
-				];
-			}
+		if ($serviceId === null) {
+			return [];
+		}
+
+		$service = $this->serviceMap->getService($serviceId);
+		if (!$service instanceof ServiceDefinition) {
+			return [];
+		}
+
+		$isContainerInterfaceType = $isContainerType->yes() || $isPsrContainerType->yes();
+		if (
+			$isContainerInterfaceType &&
+			$this->isAutowireLocator($node, $scope, $service)
+		) {
+			return [];
+		}
+
+		if (!$service->isPublic()) {
+			return [
+				RuleErrorBuilder::message(sprintf('Service "%s" is private.', $serviceId))
+					->identifier('symfonyContainer.privateService')
+					->build(),
+			];
 		}
 
 		return [];
@@ -90,6 +111,83 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		}
 		$containedClassType = new ObjectType($classReflection->getName());
 		return $isContainerServiceSubscriber->or($serviceSubscriberInterfaceType->isSuperTypeOf($containedClassType));
+	}
+
+	private function isAutowireLocator(Node $node, Scope $scope, ServiceDefinition $service): bool
+	{
+		if (!class_exists('Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator')) {
+			return false;
+		}
+
+		if (
+			!$node instanceof MethodCall
+		) {
+			return false;
+		}
+
+		$nodeParentProperty = $node->var;
+
+		if (!$nodeParentProperty instanceof Node\Expr\PropertyFetch) {
+			return false;
+		}
+
+		$nodeParentPropertyName = $nodeParentProperty->name;
+
+		if (!$nodeParentPropertyName instanceof Node\Identifier) {
+			return false;
+		}
+
+		$containerInterfacePropertyName = $nodeParentPropertyName->name;
+		$scopeClassReflection = $scope->getClassReflection();
+
+		if (!$scopeClassReflection instanceof ClassReflection) {
+			return false;
+		}
+
+		$containerInterfacePropertyReflection = $scopeClassReflection
+			->getNativeProperty($containerInterfacePropertyName);
+		$classPropertyReflection = $containerInterfacePropertyReflection->getNativeReflection();
+		$autowireLocatorAttributes = $classPropertyReflection->getAttributes(AutowireLocator::class);
+
+		return $this->isAutowireLocatorService($autowireLocatorAttributes, $service);
+	}
+
+	/**
+	 * @param  array<int, FakeReflectionAttribute|ReflectionAttribute>  $autowireLocatorAttributes
+	 */
+	private function isAutowireLocatorService(array $autowireLocatorAttributes, ServiceDefinition $service): bool
+	{
+		foreach ($autowireLocatorAttributes as $autowireLocatorAttribute) {
+			foreach ($autowireLocatorAttribute->getArgumentsExpressions() as $autowireLocatorServices) {
+				if (!$autowireLocatorServices instanceof Node\Expr\Array_) {
+					continue;
+				}
+
+				foreach ($autowireLocatorServices->items as $autowireLocatorServiceNode) {
+					/** @var Node\Expr\ArrayItem $autowireLocatorServiceNode */
+					$autowireLocatorServiceExpr = $autowireLocatorServiceNode->value;
+
+					switch (get_class($autowireLocatorServiceExpr)) {
+						case Node\Scalar\String_::class:
+							$autowireLocatorServiceClass = $autowireLocatorServiceExpr->value;
+							break;
+						case Node\Expr\ClassConstFetch::class:
+							$autowireLocatorServiceClass = $autowireLocatorServiceExpr->class instanceof Node\Name
+								? $autowireLocatorServiceExpr->class->toString()
+								: null;
+							break;
+						default:
+							$autowireLocatorServiceClass = null;
+					}
+
+					if ($service->getId() === $autowireLocatorServiceClass) {
+						return true;
+					}
+				}
+			}
+		}
+
+		return false;
 	}
 
 }

--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -5,17 +5,15 @@ namespace PHPStan\Rules\Symfony;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use PHPStan\BetterReflection\Reflection\Adapter\FakeReflectionAttribute;
-use PHPStan\BetterReflection\Reflection\Adapter\ReflectionAttribute;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Symfony\AutowireLocatorServiceMapFactory;
+use PHPStan\Symfony\DefaultServiceMap;
 use PHPStan\Symfony\ServiceMap;
 use PHPStan\TrinaryLogic;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
-use function class_exists;
+use function is_null;
 use function sprintf;
 
 /**
@@ -78,7 +76,7 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		$isContainerInterfaceType = $isContainerType->yes() || $isPsrContainerType->yes();
 		if (
 			$isContainerInterfaceType &&
-			$this->isAutowireLocator($node, $scope, $serviceId)
+			$this->isAutowireLocatorService($node, $scope, $serviceId)
 		) {
 			return [];
 		}
@@ -107,61 +105,16 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 		return $isContainerServiceSubscriber->or($serviceSubscriberInterfaceType->isSuperTypeOf($containedClassType));
 	}
 
-	private function isAutowireLocator(Node $node, Scope $scope, string $serviceId): bool
+	private function isAutowireLocatorService(Node $node, Scope $scope, string $serviceId): bool
 	{
-		if (!class_exists('Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator')) {
+		$autowireLocatorServiceMapFactory = new AutowireLocatorServiceMapFactory($node, $scope);
+		$autowireLocatorServiceMap = $autowireLocatorServiceMapFactory->create();
+
+		if (!$autowireLocatorServiceMap instanceof DefaultServiceMap) {
 			return false;
 		}
 
-		if (
-			!$node instanceof MethodCall
-		) {
-			return false;
-		}
-
-		$nodeParentProperty = $node->var;
-
-		if (!$nodeParentProperty instanceof Node\Expr\PropertyFetch) {
-			return false;
-		}
-
-		$nodeParentPropertyName = $nodeParentProperty->name;
-
-		if (!$nodeParentPropertyName instanceof Node\Identifier) {
-			return false;
-		}
-
-		$containerInterfacePropertyName = $nodeParentPropertyName->name;
-		$scopeClassReflection = $scope->getClassReflection();
-
-		if (!$scopeClassReflection instanceof ClassReflection) {
-			return false;
-		}
-
-		$containerInterfacePropertyReflection = $scopeClassReflection
-			->getNativeProperty($containerInterfacePropertyName);
-		$classPropertyReflection = $containerInterfacePropertyReflection->getNativeReflection();
-		$autowireLocatorAttributes = $classPropertyReflection->getAttributes(AutowireLocator::class);
-
-		return $this->isAutowireLocatorService($autowireLocatorAttributes, $serviceId);
-	}
-
-	/**
-	 * @param  array<int, FakeReflectionAttribute|ReflectionAttribute>  $autowireLocatorAttributes
-	 */
-	private function isAutowireLocatorService(array $autowireLocatorAttributes, string $serviceId): bool
-	{
-		foreach ($autowireLocatorAttributes as $autowireLocatorAttribute) {
-			/** @var AutowireLocator $autowireLocatorInstance */
-			$autowireLocator = $autowireLocatorAttribute->newInstance();
-			$autowireLocatorServices = $autowireLocator->value->getValues();
-
-			if (array_key_exists($serviceId, $autowireLocatorServices)) {
-				return true;
-			}
-		}
-
-		return false;
+		return !is_null($autowireLocatorServiceMap->getService($serviceId));
 	}
 
 }

--- a/src/Symfony/AutowireLocatorServiceMapFactory.php
+++ b/src/Symfony/AutowireLocatorServiceMapFactory.php
@@ -1,0 +1,110 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use InvalidArgumentException;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+use Symfony\Component\DependencyInjection\TypedReference;
+use function class_exists;
+use function count;
+use function sprintf;
+
+final class AutowireLocatorServiceMapFactory implements ServiceMapFactory
+{
+
+	/** @var Node */
+	private $node;
+
+	/** @var Scope */
+	private $scope;
+
+	public function __construct(
+		Node $node,
+		Scope $scope
+	)
+	{
+		$this->node = $node;
+		$this->scope = $scope;
+	}
+
+	public function create(): ServiceMap
+	{
+		if (!class_exists('Symfony\\Component\\DependencyInjection\\Attribute\\AutowireLocator')) {
+			return new FakeServiceMap();
+		}
+
+		if (!$this->node instanceof MethodCall) {
+			return new FakeServiceMap();
+		}
+
+		$nodeParentProperty = $this->node->var;
+
+		if (!$nodeParentProperty instanceof Node\Expr\PropertyFetch) {
+			return new FakeServiceMap();
+		}
+
+		$nodeParentPropertyName = $nodeParentProperty->name;
+
+		if (!$nodeParentPropertyName instanceof Node\Identifier) {
+			return new FakeServiceMap();
+		}
+
+		$containerInterfacePropertyName = $nodeParentPropertyName->name;
+		$scopeClassReflection = $this->scope->getClassReflection();
+
+		if (!$scopeClassReflection instanceof ClassReflection) {
+			return new FakeServiceMap();
+		}
+
+		$containerInterfacePropertyReflection = $scopeClassReflection
+			->getNativeProperty($containerInterfacePropertyName);
+		$classPropertyReflection = $containerInterfacePropertyReflection->getNativeReflection();
+		$autowireLocatorAttributesReflection = $classPropertyReflection->getAttributes(AutowireLocator::class);
+
+		if (count($autowireLocatorAttributesReflection) === 0) {
+			return new FakeServiceMap();
+		}
+
+		if (count($autowireLocatorAttributesReflection) > 1) {
+			throw new InvalidArgumentException(sprintf(
+				'Only one AutowireLocator attribute is allowed on "%s::%s".',
+				$scopeClassReflection->getName(),
+				$containerInterfacePropertyName
+			));
+		}
+
+		$autowireLocatorAttributeReflection = $autowireLocatorAttributesReflection[0];
+		/** @var AutowireLocator $autowireLocator */
+		$autowireLocator = $autowireLocatorAttributeReflection->newInstance();
+		$serviceLocatorArgument = $autowireLocator->value;
+
+		if (!$serviceLocatorArgument instanceof ServiceLocatorArgument) {
+			return new FakeServiceMap();
+		}
+
+		/** @var Service[] $services */
+		$services = [];
+
+		/** @var TypedReference $service */
+		foreach ($serviceLocatorArgument->getValues() as $id => $service) {
+			$class = $service->getType();
+			$alias = $service->getName();
+
+			$services[$id] = new Service(
+				$id,
+				$class,
+				true,
+				false,
+				$alias
+			);
+		}
+
+		return new DefaultServiceMap($services);
+	}
+
+}

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleTest.php
@@ -8,6 +8,7 @@ use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use function class_exists;
 use function interface_exists;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ContainerInterfacePrivateServiceRule>
@@ -73,6 +74,39 @@ final class ContainerInterfacePrivateServiceRuleTest extends RuleTestCase
 				__DIR__ . '/ExampleServiceSubscriber.php',
 				__DIR__ . '/ExampleServiceSubscriberFromAbstractController.php',
 				__DIR__ . '/ExampleServiceSubscriberFromLegacyController.php',
+			],
+			[]
+		);
+	}
+
+	public function testGetPrivateServiceWithoutAutowireLocatorAttribute(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			self::markTestSkipped('The test uses PHP Attributes which are available since PHP 8.0.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleAutowireLocatorEmptyService.php',
+			],
+			[
+				[
+					'Service "private" is private.',
+					22,
+				],
+			]
+		);
+	}
+
+	public function testGetPrivateServiceViaAutowireLocatorAttribute(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			self::markTestSkipped('The test uses PHP Attributes which are available since PHP 8.0.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleAutowireLocatorService.php',
 			],
 			[]
 		);

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -9,6 +9,7 @@ use PHPStan\Symfony\XmlServiceMapFactory;
 use PHPStan\Testing\RuleTestCase;
 use function class_exists;
 use function interface_exists;
+use const PHP_VERSION_ID;
 
 /**
  * @extends RuleTestCase<ContainerInterfaceUnknownServiceRule>
@@ -67,6 +68,43 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		$this->analyse(
 			[
 				__DIR__ . '/ExampleServiceSubscriber.php',
+			],
+			[]
+		);
+	}
+
+	public function testGetPrivateServiceWithoutAutowireLocatorAttribute(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			self::markTestSkipped('The test uses PHP Attributes which are available since PHP 8.0.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleAutowireLocatorEmptyService.php',
+			],
+			[
+				[
+					'Service "Foo" is not registered in the AutowireLocator.',
+					21,
+				],
+				[
+					'Service "private" is not registered in the AutowireLocator.',
+					22,
+				],
+			]
+		);
+	}
+
+	public function testGetPrivateServiceViaAutowireLocatorAttribute(): void
+	{
+		if (PHP_VERSION_ID < 80000) {
+			self::markTestSkipped('The test uses PHP Attributes which are available since PHP 8.0.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleAutowireLocatorService.php',
 			],
 			[]
 		);

--- a/tests/Rules/Symfony/ExampleAutowireLocatorEmptyService.php
+++ b/tests/Rules/Symfony/ExampleAutowireLocatorEmptyService.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+
+final class ExampleAutowireLocatorEmptyService
+{
+
+	public function __construct(
+		#[AutowireLocator([])]
+		private ContainerInterface $locator
+	)
+	{
+		$this->locator = $locator;
+	}
+
+	public function privateServiceInLocator(): void
+	{
+		$this->locator->get('Foo');
+		$this->locator->get('private');
+	}
+
+}

--- a/tests/Rules/Symfony/ExampleAutowireLocatorService.php
+++ b/tests/Rules/Symfony/ExampleAutowireLocatorService.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutowireLocator;
+
+final class ExampleAutowireLocatorService
+{
+
+	public function __construct(
+		#[AutowireLocator([
+			'Foo' => 'Foo',
+			'private' => 'Foo',
+		])]
+		private ContainerInterface $locator
+	)
+	{
+	}
+
+	public function privateServiceInLocator(): void
+	{
+		$this->locator->get('Foo');
+		$this->locator->get('private');
+	}
+
+}


### PR DESCRIPTION
I implemented initial support for the `#[AutowireLocator]` attribute. See https://symfony.com/blog/new-in-symfony-6-4-autowirelocator-and-autowireiterator-attributes

The simple syntax is supported now:
```php
#[AutowireLocator([FooHandler::class, BarHandler::class])]
```

It also supports when classes are specified via string:
```php
#[AutowireLocator(['App\FooHandler'])]
```

The advanced syntax described in the blog post is ~~not~~ also supported ~~yet~~ now:
```php
#[AutowireLocator([
    'foo' => FooHandler::class,
    'bar' => new SubscribedService(type: 'string', attributes: new Autowire('%some.parameter%')),
    'optionalBaz' => '?'.BazHandler::class,
])]
private ContainerInterface $handlers,
```

~~Maybe someone else wants to figure this out. Unfortunately I have no more time left to do it in the coming days.~~

Edit 2: I just found out how I can both simplify this a lot and implement the advanced syntax by just creating an instance of the AutowireLocator attribute. And I'll move this to `AutowireLoaderServiceMapFactory` so it will be also available for `PHPStan\Rules\Symfony\ContainerInterfaceUnknownServiceRule`.

closes #411 