### PR TITLE
Add result cache meta extension for DI container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-simplexml": "*",
-    "phpstan/phpstan": "^2.0"
+    "phpstan/phpstan": "^2.1.2"
   },
   "conflict": {
     "symfony/framework-bundle": "<3.0"

--- a/extension.neon
+++ b/extension.neon
@@ -363,3 +363,8 @@ services:
 	-
 		factory: PHPStan\Type\Symfony\ExtensionGetConfigurationReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
+
+	-
+		class: PHPStan\Symfony\SymfonyContainerResultCacheMetaExtension
+		tags:
+			- phpstan.resultCacheMetaExtension

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
+use function array_map;
+use function hash;
+use function serialize;
+
+final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaExtension
+{
+
+	private ParameterMapFactory $parameterMapFactory;
+
+	private ServiceMapFactory $serviceMapFactory;
+
+	public function __construct(
+		ParameterMapFactory $parameterMapFactory,
+		ServiceMapFactory $serviceMapFactory
+	)
+	{
+		$this->parameterMapFactory = $parameterMapFactory;
+		$this->serviceMapFactory = $serviceMapFactory;
+	}
+
+	public function getKey(): string
+	{
+		return 'symfonyDiContainer';
+	}
+
+	public function getHash(): string
+	{
+		return hash('sha256', serialize([
+			'parameters' => array_map(
+				static fn (ParameterDefinition $parameter) => [
+					'name' => $parameter->getKey(),
+					'value' => $parameter->getValue(),
+				],
+				$this->parameterMapFactory->create()->getParameters(),
+			),
+			'services' => array_map(
+				static fn (ServiceDefinition $service) => [
+					'id' => $service->getId(),
+					'class' => $service->getClass(),
+					'public' => $service->isPublic() ? 'yes' : 'no',
+					'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
+					'alias' => $service->getAlias(),
+				],
+				$this->serviceMapFactory->create()->getServices(),
+			),
+		]));
+	}
+
+}

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -10,17 +10,14 @@ use function serialize;
 final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaExtension
 {
 
-	private ParameterMapFactory $parameterMapFactory;
+	private ParameterMap $parameterMap;
 
-	private ServiceMapFactory $serviceMapFactory;
+	private ServiceMap $serviceMap;
 
-	public function __construct(
-		ParameterMapFactory $parameterMapFactory,
-		ServiceMapFactory $serviceMapFactory
-	)
+	public function __construct(ParameterMap $parameterMap, ServiceMap $serviceMap)
 	{
-		$this->parameterMapFactory = $parameterMapFactory;
-		$this->serviceMapFactory = $serviceMapFactory;
+		$this->parameterMap = $parameterMap;
+		$this->serviceMap = $serviceMap;
 	}
 
 	public function getKey(): string
@@ -36,7 +33,7 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 					'name' => $parameter->getKey(),
 					'value' => $parameter->getValue(),
 				],
-				$this->parameterMapFactory->create()->getParameters(),
+				$this->parameterMap->getParameters(),
 			),
 			'services' => array_map(
 				static fn (ServiceDefinition $service) => [
@@ -46,7 +43,7 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 					'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
 					'alias' => $service->getAlias(),
 				],
-				$this->serviceMapFactory->create()->getServices(),
+				$this->serviceMap->getServices(),
 			),
 		]));
 	}

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -6,6 +6,7 @@ use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use function array_map;
 use function hash;
 use function serialize;
+use function sort;
 
 final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaExtension
 {
@@ -29,20 +30,32 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 	{
 		return hash('sha256', serialize([
 			'parameters' => array_map(
-				static fn (ParameterDefinition $parameter) => [
+				static fn (ParameterDefinition $parameter): array => [
 					'name' => $parameter->getKey(),
 					'value' => $parameter->getValue(),
 				],
 				$this->parameterMap->getParameters(),
 			),
 			'services' => array_map(
-				static fn (ServiceDefinition $service) => [
-					'id' => $service->getId(),
-					'class' => $service->getClass(),
-					'public' => $service->isPublic() ? 'yes' : 'no',
-					'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
-					'alias' => $service->getAlias(),
-				],
+				static function (ServiceDefinition $service): array {
+					$serviceTags = array_map(
+						static fn (ServiceTag $tag) => [
+							'name' => $tag->getName(),
+							'attributes' => $tag->getAttributes(),
+						],
+						$service->getTags(),
+					);
+					sort($serviceTags);
+
+					return [
+						'id' => $service->getId(),
+						'class' => $service->getClass(),
+						'public' => $service->isPublic() ? 'yes' : 'no',
+						'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
+						'alias' => $service->getAlias(),
+						'tags' => $serviceTags,
+					];
+				},
 				$this->serviceMap->getServices(),
 			),
 		]));

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -6,8 +6,8 @@ use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use function array_map;
 use function hash;
 use function ksort;
-use function serialize;
 use function sort;
+use function var_export;
 
 final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaExtension
 {
@@ -56,7 +56,7 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 		}
 		ksort($services);
 
-		return hash('sha256', serialize(['parameters' => $parameters, 'services' => $services]));
+		return hash('sha256', var_export(['parameters' => $parameters, 'services' => $services], true));
 	}
 
 }

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -5,6 +5,7 @@ namespace PHPStan\Symfony;
 use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use function array_map;
 use function hash;
+use function ksort;
 use function serialize;
 use function sort;
 
@@ -28,37 +29,34 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 
 	public function getHash(): string
 	{
-		return hash('sha256', serialize([
-			'parameters' => array_map(
-				static fn (ParameterDefinition $parameter): array => [
-					'name' => $parameter->getKey(),
-					'value' => $parameter->getValue(),
-				],
-				$this->parameterMap->getParameters(),
-			),
-			'services' => array_map(
-				static function (ServiceDefinition $service): array {
-					$serviceTags = array_map(
-						static fn (ServiceTag $tag) => [
-							'name' => $tag->getName(),
-							'attributes' => $tag->getAttributes(),
-						],
-						$service->getTags(),
-					);
-					sort($serviceTags);
+		$services = $parameters = [];
 
-					return [
-						'id' => $service->getId(),
-						'class' => $service->getClass(),
-						'public' => $service->isPublic() ? 'yes' : 'no',
-						'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
-						'alias' => $service->getAlias(),
-						'tags' => $serviceTags,
-					];
-				},
-				$this->serviceMap->getServices(),
-			),
-		]));
+		foreach ($this->parameterMap->getParameters() as $parameter) {
+			$parameters[$parameter->getKey()] = $parameter->getValue();
+		}
+		ksort($parameters);
+
+		foreach ($this->serviceMap->getServices() as $service) {
+			$serviceTags = array_map(
+				static fn (ServiceTag $tag) => [
+					'name' => $tag->getName(),
+					'attributes' => $tag->getAttributes(),
+				],
+				$service->getTags(),
+			);
+			sort($serviceTags);
+
+			$services[$service->getId()] = [
+				'class' => $service->getClass(),
+				'public' => $service->isPublic() ? 'yes' : 'no',
+				'synthetic' => $service->isSynthetic() ? 'yes' : 'no',
+				'alias' => $service->getAlias(),
+				'tags' => $serviceTags,
+			];
+		}
+		ksort($services);
+
+		return hash('sha256', serialize(['parameters' => $parameters, 'services' => $services]));
 	}
 
 }

--- a/src/Symfony/XmlParameterMapFactory.php
+++ b/src/Symfony/XmlParameterMapFactory.php
@@ -8,12 +8,15 @@ use SimpleXMLElement;
 use function base64_decode;
 use function file_get_contents;
 use function is_numeric;
+use function ksort;
 use function simplexml_load_string;
 use function sprintf;
 use function strpos;
 
 final class XmlParameterMapFactory implements ParameterMapFactory
 {
+
+	private ?ParameterMap $parameterMap = null;
 
 	private ?string $containerXml = null;
 
@@ -24,6 +27,10 @@ final class XmlParameterMapFactory implements ParameterMapFactory
 
 	public function create(): ParameterMap
 	{
+		if ($this->parameterMap !== null) {
+			return $this->parameterMap;
+		}
+
 		if ($this->containerXml === null) {
 			return new FakeParameterMap();
 		}
@@ -52,7 +59,9 @@ final class XmlParameterMapFactory implements ParameterMapFactory
 			$parameters[$parameter->getKey()] = $parameter;
 		}
 
-		return new DefaultParameterMap($parameters);
+		ksort($parameters);
+
+		return $this->parameterMap = new DefaultParameterMap($parameters);
 	}
 
 	/**

--- a/src/Symfony/XmlParameterMapFactory.php
+++ b/src/Symfony/XmlParameterMapFactory.php
@@ -6,6 +6,7 @@ use InvalidArgumentException;
 use PHPStan\ShouldNotHappenException;
 use SimpleXMLElement;
 use function base64_decode;
+use function count;
 use function file_get_contents;
 use function is_numeric;
 use function ksort;
@@ -41,16 +42,19 @@ final class XmlParameterMapFactory implements ParameterMapFactory
 
 		/** @var Parameter[] $parameters */
 		$parameters = [];
-		foreach ($xml->parameters->parameter as $def) {
-			/** @var SimpleXMLElement $attrs */
-			$attrs = $def->attributes();
 
-			$parameter = new Parameter(
-				(string) $attrs->key,
-				$this->getNodeValue($def),
-			);
+		if (count($xml->parameters) > 0) {
+			foreach ($xml->parameters->parameter as $def) {
+				/** @var SimpleXMLElement $attrs */
+				$attrs = $def->attributes();
 
-			$parameters[$parameter->getKey()] = $parameter;
+				$parameter = new Parameter(
+					(string) $attrs->key,
+					$this->getNodeValue($def),
+				);
+
+				$parameters[$parameter->getKey()] = $parameter;
+			}
 		}
 
 		ksort($parameters);

--- a/src/Symfony/XmlParameterMapFactory.php
+++ b/src/Symfony/XmlParameterMapFactory.php
@@ -16,8 +16,6 @@ use function strpos;
 final class XmlParameterMapFactory implements ParameterMapFactory
 {
 
-	private ?ParameterMap $parameterMap = null;
-
 	private ?string $containerXml = null;
 
 	public function __construct(?string $containerXmlPath)
@@ -27,10 +25,6 @@ final class XmlParameterMapFactory implements ParameterMapFactory
 
 	public function create(): ParameterMap
 	{
-		if ($this->parameterMap !== null) {
-			return $this->parameterMap;
-		}
-
 		if ($this->containerXml === null) {
 			return new FakeParameterMap();
 		}
@@ -61,7 +55,7 @@ final class XmlParameterMapFactory implements ParameterMapFactory
 
 		ksort($parameters);
 
-		return $this->parameterMap = new DefaultParameterMap($parameters);
+		return new DefaultParameterMap($parameters);
 	}
 
 	/**

--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Symfony;
 
 use SimpleXMLElement;
+use function count;
 use function file_get_contents;
 use function ksort;
 use function simplexml_load_string;
@@ -40,35 +41,38 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 		$services = [];
 		/** @var Service[] $aliases */
 		$aliases = [];
-		foreach ($xml->services->service as $def) {
-			/** @var SimpleXMLElement $attrs */
-			$attrs = $def->attributes();
-			if (!isset($attrs->id)) {
-				continue;
-			}
 
-			$serviceTags = [];
-			foreach ($def->tag as $tag) {
-				$tagAttrs = ((array) $tag->attributes())['@attributes'] ?? [];
-				$tagName = $tagAttrs['name'];
-				unset($tagAttrs['name']);
+		if (count($xml->services) > 0) {
+			foreach ($xml->services->service as $def) {
+				/** @var SimpleXMLElement $attrs */
+				$attrs = $def->attributes();
+				if (!isset($attrs->id)) {
+					continue;
+				}
 
-				$serviceTags[] = new ServiceTag($tagName, $tagAttrs);
-			}
+				$serviceTags = [];
+				foreach ($def->tag as $tag) {
+					$tagAttrs = ((array) $tag->attributes())['@attributes'] ?? [];
+					$tagName = $tagAttrs['name'];
+					unset($tagAttrs['name']);
 
-			$service = new Service(
-				$this->cleanServiceId((string) $attrs->id),
-				isset($attrs->class) ? (string) $attrs->class : null,
-				isset($attrs->public) && (string) $attrs->public === 'true',
-				isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
-				isset($attrs->alias) ? $this->cleanServiceId((string) $attrs->alias) : null,
-				$serviceTags,
-			);
+					$serviceTags[] = new ServiceTag($tagName, $tagAttrs);
+				}
 
-			if ($service->getAlias() !== null) {
-				$aliases[] = $service;
-			} else {
-				$services[$service->getId()] = $service;
+				$service = new Service(
+					$this->cleanServiceId((string) $attrs->id),
+					isset($attrs->class) ? (string) $attrs->class : null,
+					isset($attrs->public) && (string) $attrs->public === 'true',
+					isset($attrs->synthetic) && (string) $attrs->synthetic === 'true',
+					isset($attrs->alias) ? $this->cleanServiceId((string) $attrs->alias) : null,
+					$serviceTags,
+				);
+
+				if ($service->getAlias() !== null) {
+					$aliases[] = $service;
+				} else {
+					$services[$service->getId()] = $service;
+				}
 			}
 		}
 		foreach ($aliases as $service) {

--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -4,6 +4,7 @@ namespace PHPStan\Symfony;
 
 use SimpleXMLElement;
 use function file_get_contents;
+use function ksort;
 use function simplexml_load_string;
 use function sprintf;
 use function strpos;
@@ -11,6 +12,8 @@ use function substr;
 
 final class XmlServiceMapFactory implements ServiceMapFactory
 {
+
+	private ?ServiceMap $serviceMap = null;
 
 	private ?string $containerXml = null;
 
@@ -21,6 +24,10 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 
 	public function create(): ServiceMap
 	{
+		if ($this->serviceMap !== null) {
+			return $this->serviceMap;
+		}
+
 		if ($this->containerXml === null) {
 			return new FakeServiceMap();
 		}
@@ -85,7 +92,9 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 			);
 		}
 
-		return new DefaultServiceMap($services);
+		ksort($services);
+
+		return $this->serviceMap = new DefaultServiceMap($services);
 	}
 
 	private function cleanServiceId(string $id): string

--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -13,8 +13,6 @@ use function substr;
 final class XmlServiceMapFactory implements ServiceMapFactory
 {
 
-	private ?ServiceMap $serviceMap = null;
-
 	private ?string $containerXml = null;
 
 	public function __construct(?string $containerXmlPath)
@@ -24,10 +22,6 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 
 	public function create(): ServiceMap
 	{
-		if ($this->serviceMap !== null) {
-			return $this->serviceMap;
-		}
-
 		if ($this->containerXml === null) {
 			return new FakeServiceMap();
 		}
@@ -94,7 +88,7 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 
 		ksort($services);
 
-		return $this->serviceMap = new DefaultServiceMap($services);
+		return new DefaultServiceMap($services);
 	}
 
 	private function cleanServiceId(string $id): string

--- a/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
+++ b/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
@@ -1,0 +1,304 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Symfony;
+
+use PHPStan\Testing\PHPStanTestCase;
+use function count;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+
+final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
+{
+
+	private static string $configFilePath;
+
+	/**
+	 * This test has to check if hash of the Symfony Container is correctly calculated,
+	 * in order to do that we need to dynamically create a temporary configuration file
+	 * because `PHPStanTestCase::getContainer()` caches container under key calculated from
+	 * additional config files' paths, so we can't reuse the same config file between tests.
+	 */
+	public static function getAdditionalConfigFiles(): array
+	{
+		return [
+			__DIR__ . '/../../extension.neon',
+			self::$configFilePath,
+		];
+	}
+
+	/**
+	 * @param list<string> $sameHashXmlContents
+	 *
+	 * @dataProvider provideContainerHashIsCalculatedCorrectlyCases
+	 */
+	public function testContainerHashIsCalculatedCorrectly(
+		array $sameHashXmlContents,
+		string $invalidatingXmlContent
+	): void
+	{
+		$hash = null;
+
+		self::assertGreaterThan(0, count($sameHashXmlContents));
+
+		foreach ($sameHashXmlContents as $xmlContent) {
+			$currentHash = $this->calculateSymfonyContainerHash($xmlContent);
+
+			if ($hash === null) {
+				$hash = $currentHash;
+			} else {
+				self::assertSame($hash, $currentHash);
+			}
+		}
+
+		self::assertNotSame($hash, $this->calculateSymfonyContainerHash($invalidatingXmlContent));
+	}
+
+	/**
+	 * @return iterable<string, array{list<string>, string}>
+	 */
+	public static function provideContainerHashIsCalculatedCorrectlyCases(): iterable
+	{
+		yield 'service "class" changes' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" />
+							<service id="Bar" class="Bar" />
+						</services>
+					</container>
+					XML,
+				// Swapping services order in XML file does not affect the calculated hash
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Bar" class="Bar" />
+							<service id="Foo" class="Foo" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" />
+						<service id="Bar" class="BarAdapter" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service visibility changes' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" public="true" />
+						</services>
+					</container>
+					XML,
+				// Placement of XML attributes does not affect the calculated hash
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" public="true" class="Foo" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" public="false" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service syntheticity changes' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" synthetic="false" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" synthetic="true" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service alias changes' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" />
+							<service id="Bar" class="Bar" />
+							<service id="Baz" alias="Foo" />
+						</services>
+					</container>
+					XML,
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Baz" alias="Foo" />
+							<service id="Foo" class="Foo" />
+							<service id="Bar" class="Bar" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" />
+						<service id="Bar" class="Bar" />
+						<service id="Baz" alias="Bar" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'new service added' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" />
+						<service id="Bar" class="Bar" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service removed' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo" />
+							<service id="Bar" class="Bar" />
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo" />
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'parameter value changes' => [
+			[
+				<<<'XML'
+					<container>
+						<parameters>
+							<parameter key="foo">foo</parameter>
+							<parameter key="bar">bar</parameter>
+						</parameters>
+					</container>
+					XML,
+				// Swapping parameters order in XML file does not affect the calculated hash
+				<<<'XML'
+					<container>
+						<parameters>
+							<parameter key="bar">bar</parameter>
+							<parameter key="foo">foo</parameter>
+						</parameters>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<parameters>
+						<parameter key="foo">foo</parameter>
+						<parameter key="bar">buzz</parameter>
+					</parameters>
+				</container>
+				XML,
+		];
+
+		yield 'new parameter added' => [
+			[
+				<<<'XML'
+					<container>
+						<parameters>
+							<parameter key="foo">foo</parameter>
+						</parameters>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<parameters>
+						<parameter key="foo">foo</parameter>
+						<parameter key="bar">bar</parameter>
+					</parameters>
+				</container>
+				XML,
+		];
+
+		yield 'parameter removed' => [
+			[
+				<<<'XML'
+					<container>
+						<parameters>
+							<parameter key="foo">foo</parameter>
+							<parameter key="bar">bar</parameter>
+						</parameters>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<parameters>
+						<parameter key="foo">foo</parameter>
+					</parameters>
+				</container>
+				XML,
+		];
+	}
+
+	private function calculateSymfonyContainerHash(string $xmlContent): string
+	{
+		$symfonyContainerXmlPath = tempnam(sys_get_temp_dir(), 'phpstan-meta-extension-test-container-xml-');
+		self::$configFilePath = tempnam(sys_get_temp_dir(), 'phpstan-meta-extension-test-config-') . '.neon';
+
+		file_put_contents(
+			self::$configFilePath,
+			<<<NEON
+				parameters:
+					symfony:
+						containerXmlPath: '$symfonyContainerXmlPath'
+				NEON,
+		);
+		file_put_contents($symfonyContainerXmlPath, $xmlContent);
+
+		$metaExtension = new SymfonyContainerResultCacheMetaExtension(
+			self::getContainer()->getByType(ParameterMap::class),
+			self::getContainer()->getByType(ServiceMap::class),
+		);
+
+		return $metaExtension->getHash();
+	}
+
+}

--- a/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
+++ b/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
@@ -167,6 +167,89 @@ final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 				XML,
 		];
 
+		yield 'service tag attributes changes' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo">
+								<tag name="foo.bar" baz="bar"/>
+								<tag name="foo.baz" baz="baz"/>
+							</service>
+						</services>
+					</container>
+					XML,
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo">
+								<tag name="foo.baz" baz="baz"/>
+								<tag name="foo.bar" baz="bar"/>
+							</service>
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo">
+							<tag name="foo.bar" baz="bar"/>
+							<tag name="foo.baz" baz="buzz"/>
+						</service>
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service tag added' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo">
+								<tag name="foo.bar" baz="bar"/>
+							</service>
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo">
+							<tag name="foo.bar" baz="bar"/>
+							<tag name="foo.baz" baz="baz"/>
+						</service>
+					</services>
+				</container>
+				XML,
+		];
+
+		yield 'service tag removed' => [
+			[
+				<<<'XML'
+					<container>
+						<services>
+							<service id="Foo" class="Foo">
+								<tag name="foo.bar" baz="bar"/>
+								<tag name="foo.baz" baz="baz"/>
+							</service>
+						</services>
+					</container>
+					XML,
+			],
+			<<<'XML'
+				<container>
+					<services>
+						<service id="Foo" class="Foo">
+							<tag name="foo.bar" baz="bar"/>
+						</service>
+					</services>
+				</container>
+				XML,
+		];
+
 		yield 'new service added' => [
 			[
 				<<<'XML'

--- a/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
+++ b/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
@@ -4,45 +4,33 @@ namespace PHPStan\Symfony;
 
 use PHPStan\Testing\PHPStanTestCase;
 use function count;
-use function file_put_contents;
-use function sys_get_temp_dir;
-use function tempnam;
 
+/**
+ * @phpstan-type ContainerContents array{parameters?: ParameterMap, services?: ServiceMap}
+ */
 final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 {
 
-	private static string $configFilePath;
-
 	/**
-	 * This test has to check if hash of the Symfony Container is correctly calculated,
-	 * in order to do that we need to dynamically create a temporary configuration file
-	 * because `PHPStanTestCase::getContainer()` caches container under key calculated from
-	 * additional config files' paths, so we can't reuse the same config file between tests.
-	 */
-	public static function getAdditionalConfigFiles(): array
-	{
-		return [
-			__DIR__ . '/../../extension.neon',
-			self::$configFilePath,
-		];
-	}
-
-	/**
-	 * @param list<string> $sameHashXmlContents
+	 * @param list<ContainerContents> $sameHashContents
+	 * @param ContainerContents $invalidatingContent
 	 *
 	 * @dataProvider provideContainerHashIsCalculatedCorrectlyCases
 	 */
 	public function testContainerHashIsCalculatedCorrectly(
-		array $sameHashXmlContents,
-		string $invalidatingXmlContent
+		array $sameHashContents,
+		array $invalidatingContent
 	): void
 	{
 		$hash = null;
 
-		self::assertGreaterThan(0, count($sameHashXmlContents));
+		self::assertGreaterThan(0, count($sameHashContents));
 
-		foreach ($sameHashXmlContents as $xmlContent) {
-			$currentHash = $this->calculateSymfonyContainerHash($xmlContent);
+		foreach ($sameHashContents as $content) {
+			$currentHash = (new SymfonyContainerResultCacheMetaExtension(
+				$content['parameters'] ?? new DefaultParameterMap([]),
+				$content['services'] ?? new DefaultServiceMap([]),
+			))->getHash();
 
 			if ($hash === null) {
 				$hash = $currentHash;
@@ -51,337 +39,256 @@ final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 			}
 		}
 
-		self::assertNotSame($hash, $this->calculateSymfonyContainerHash($invalidatingXmlContent));
+		self::assertNotSame(
+			$hash,
+			(new SymfonyContainerResultCacheMetaExtension(
+				$invalidatingContent['parameters'] ?? new DefaultParameterMap([]),
+				$invalidatingContent['services'] ?? new DefaultServiceMap([]),
+			))->getHash(),
+		);
 	}
 
 	/**
-	 * @return iterable<string, array{list<string>, string}>
+	 * @return iterable<string, array{list<ContainerContents>, ContainerContents}>
 	 */
 	public static function provideContainerHashIsCalculatedCorrectlyCases(): iterable
 	{
 		yield 'service "class" changes' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" />
-							<service id="Bar" class="Bar" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+						new Service('Bar', 'Bar', true, false, null),
+					]),
+				],
 				// Swapping services order in XML file does not affect the calculated hash
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Bar" class="Bar" />
-							<service id="Foo" class="Foo" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Bar', 'Bar', true, false, null),
+						new Service('Foo', 'Foo', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" />
-						<service id="Bar" class="BarAdapter" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null),
+					new Service('Bar', 'BarAdapter', true, false, null),
+				]),
+			],
 		];
 
 		yield 'service visibility changes' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" public="true" />
-						</services>
-					</container>
-					XML,
-				// Placement of XML attributes does not affect the calculated hash
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" public="true" class="Foo" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" public="false" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', false, false, null),
+				]),
+			],
 		];
 
 		yield 'service syntheticity changes' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" synthetic="false" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" synthetic="true" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, true, null),
+				]),
+			],
 		];
 
 		yield 'service alias changes' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" />
-							<service id="Bar" class="Bar" />
-							<service id="Baz" alias="Foo" />
-						</services>
-					</container>
-					XML,
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Baz" alias="Foo" />
-							<service id="Foo" class="Foo" />
-							<service id="Bar" class="Bar" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+						new Service('Bar', 'Bar', true, false, null),
+						new Service('Baz', null, true, false, 'Foo'),
+					]),
+				],
+				// Swapping services order in XML file does not affect the calculated hash
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Baz', null, true, false, 'Foo'),
+						new Service('Bar', 'Bar', true, false, null),
+						new Service('Foo', 'Foo', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" />
-						<service id="Bar" class="Bar" />
-						<service id="Baz" alias="Bar" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null),
+					new Service('Bar', 'Bar', true, false, null),
+					new Service('Baz', null, true, false, 'Bar'),
+				]),
+			],
 		];
 
 		yield 'service tag attributes changes' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo">
-								<tag name="foo.bar" baz="bar"/>
-								<tag name="foo.baz" baz="baz"/>
-							</service>
-						</services>
-					</container>
-					XML,
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo">
-								<tag name="foo.baz" baz="baz"/>
-								<tag name="foo.bar" baz="bar"/>
-							</service>
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null, [
+							new ServiceTag('foo.bar', ['baz' => 'bar']),
+							new ServiceTag('foo.baz', ['baz' => 'baz']),
+						]),
+					]),
+				],
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null, [
+							new ServiceTag('foo.baz', ['baz' => 'baz']),
+							new ServiceTag('foo.bar', ['baz' => 'bar']),
+						]),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo">
-							<tag name="foo.bar" baz="bar"/>
-							<tag name="foo.baz" baz="buzz"/>
-						</service>
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null, [
+						new ServiceTag('foo.bar', ['baz' => 'bar']),
+						new ServiceTag('foo.baz', ['baz' => 'buzz']),
+					]),
+				]),
+			],
 		];
 
 		yield 'service tag added' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo">
-								<tag name="foo.bar" baz="bar"/>
-							</service>
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null, [
+							new ServiceTag('foo.bar', ['baz' => 'bar']),
+						]),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo">
-							<tag name="foo.bar" baz="bar"/>
-							<tag name="foo.baz" baz="baz"/>
-						</service>
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null, [
+						new ServiceTag('foo.bar', ['baz' => 'bar']),
+						new ServiceTag('foo.baz', ['baz' => 'baz']),
+					]),
+				]),
+			],
 		];
 
 		yield 'service tag removed' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo">
-								<tag name="foo.bar" baz="bar"/>
-								<tag name="foo.baz" baz="baz"/>
-							</service>
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null, [
+							new ServiceTag('foo.bar', ['baz' => 'bar']),
+							new ServiceTag('foo.baz', ['baz' => 'baz']),
+						]),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo">
-							<tag name="foo.bar" baz="bar"/>
-						</service>
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null, [
+						new ServiceTag('foo.bar', ['baz' => 'bar']),
+					]),
+				]),
+			],
 		];
 
 		yield 'new service added' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" />
-						<service id="Bar" class="Bar" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null),
+					new Service('Bar', 'Bar', true, false, null),
+				]),
+			],
 		];
 
 		yield 'service removed' => [
 			[
-				<<<'XML'
-					<container>
-						<services>
-							<service id="Foo" class="Foo" />
-							<service id="Bar" class="Bar" />
-						</services>
-					</container>
-					XML,
+				[
+					'services' => new DefaultServiceMap([
+						new Service('Foo', 'Foo', true, false, null),
+						new Service('Bar', 'Bar', true, false, null),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<services>
-						<service id="Foo" class="Foo" />
-					</services>
-				</container>
-				XML,
+			[
+				'services' => new DefaultServiceMap([
+					new Service('Foo', 'Foo', true, false, null),
+				]),
+			],
 		];
 
 		yield 'parameter value changes' => [
 			[
-				<<<'XML'
-					<container>
-						<parameters>
-							<parameter key="foo">foo</parameter>
-							<parameter key="bar">bar</parameter>
-						</parameters>
-					</container>
-					XML,
-				// Swapping parameters order in XML file does not affect the calculated hash
-				<<<'XML'
-					<container>
-						<parameters>
-							<parameter key="bar">bar</parameter>
-							<parameter key="foo">foo</parameter>
-						</parameters>
-					</container>
-					XML,
+				[
+					'parameters' => new DefaultParameterMap([
+						new Parameter('foo', 'foo'),
+						new Parameter('bar', 'bar'),
+					]),
+				],
+				[
+					'parameters' => new DefaultParameterMap([
+						new Parameter('bar', 'bar'),
+						new Parameter('foo', 'foo'),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<parameters>
-						<parameter key="foo">foo</parameter>
-						<parameter key="bar">buzz</parameter>
-					</parameters>
-				</container>
-				XML,
+			[
+				'parameters' => new DefaultParameterMap([
+					new Parameter('foo', 'foo'),
+					new Parameter('bar', 'buzz'),
+				]),
+			],
 		];
 
 		yield 'new parameter added' => [
 			[
-				<<<'XML'
-					<container>
-						<parameters>
-							<parameter key="foo">foo</parameter>
-						</parameters>
-					</container>
-					XML,
+				[
+					'parameters' => new DefaultParameterMap([
+						new Parameter('foo', 'foo'),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<parameters>
-						<parameter key="foo">foo</parameter>
-						<parameter key="bar">bar</parameter>
-					</parameters>
-				</container>
-				XML,
+			[
+				'parameters' => new DefaultParameterMap([
+					new Parameter('foo', 'foo'),
+					new Parameter('bar', 'bar'),
+				]),
+			],
 		];
 
 		yield 'parameter removed' => [
 			[
-				<<<'XML'
-					<container>
-						<parameters>
-							<parameter key="foo">foo</parameter>
-							<parameter key="bar">bar</parameter>
-						</parameters>
-					</container>
-					XML,
+				[
+					'parameters' => new DefaultParameterMap([
+						new Parameter('foo', 'foo'),
+						new Parameter('bar', 'bar'),
+					]),
+				],
 			],
-			<<<'XML'
-				<container>
-					<parameters>
-						<parameter key="foo">foo</parameter>
-					</parameters>
-				</container>
-				XML,
+			[
+				'parameters' => new DefaultParameterMap([
+					new Parameter('foo', 'foo'),
+				]),
+			],
 		];
-	}
-
-	private function calculateSymfonyContainerHash(string $xmlContent): string
-	{
-		$symfonyContainerXmlPath = tempnam(sys_get_temp_dir(), 'phpstan-meta-extension-test-container-xml-');
-		self::$configFilePath = tempnam(sys_get_temp_dir(), 'phpstan-meta-extension-test-config-') . '.neon';
-
-		file_put_contents(
-			self::$configFilePath,
-			<<<NEON
-				parameters:
-					symfony:
-						containerXmlPath: '$symfonyContainerXmlPath'
-				NEON,
-		);
-		file_put_contents($symfonyContainerXmlPath, $xmlContent);
-
-		$metaExtension = new SymfonyContainerResultCacheMetaExtension(
-			self::getContainer()->getByType(ParameterMap::class),
-			self::getContainer()->getByType(ServiceMap::class),
-		);
-
-		return $metaExtension->getHash();
 	}
 
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This feature was brought to you thanks to [GetResponse](https://getresponse.com) - Marketing Software for Professional Email Marketing, which paid for my work on this.

Fixes phpstan/phpstan-symfony#255, continues phpstan/phpstan-src#3765.

---

Following [this experiment's results](https://github.com/phpstan/phpstan-symfony/issues/255#issuecomment-2373929376) I decided to calculate meta hash based on DI container's actual content (params and services), without interacting with XML file directly. `ParameterMapFactory` and `ServiceMapFactory` were used for retrieving data, also I implemented "singleton" approach there, so the XML file won't be processed multiple times (once for calculating hash, then for processing rules).

I start with a draft PR so I can get early feedback. I also need help when it comes to testing this, because I don't see e2e approach here. I wanted to test it on our codebase, but it's really cumbersome to setup Composer dependencies to get dev version of PHPStan and the plugin 😅.