### PR TITLE
using messenger HandleTrait as QueryBus with appropriate result typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,20 +232,20 @@ class QueryBus
 
     public function dispatch(object $query): mixed
     {
-        return $this->handle($query); // Return type will be inferred
+        return $this->handle($query); // Return type will be inferred in calling code as query result
     }
 
     // Multiple methods per class example
     public function execute(object $message): mixed
     {
-        return $this->handle($message);
+        return $this->handle($message); // Return type will be inferred in calling code as query result
     }
 }
 
 // Interface-based configuration example
 interface QueryBusInterface
 {
-    public function dispatch(object $query): mixed;
+    public function dispatch(object $query): mixed; // Return type will be inferred in calling code as query result
 }
 
 class QueryBusWithInterface implements QueryBusInterface
@@ -263,7 +263,7 @@ class QueryBusWithInterface implements QueryBusInterface
     }
 }
 
-// Usage examples with proper type inference
+// Examples of use with proper type inference
 $query = new GetProductQuery($productId);
 $queryBus = new QueryBus($messageBus);
 $queryBusWithInterface = new QueryBusWithInterface($messageBus);
@@ -271,4 +271,5 @@ $queryBusWithInterface = new QueryBusWithInterface($messageBus);
 $product = $queryBus->dispatch($query); // Returns: Product
 $product2 = $queryBus->execute($query); // Returns: Product
 $product3 = $queryBusWithInterface->dispatch($query); // Returns: Product
+// Without the feature all above query bus results would be default 'mixed'.
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This extension provides following features:
 * Provides correct return type for `Extension::getConfiguration()` method.
 * Provides correct return type for `CacheInterface::get()` method based on the callback return type.
 * Provides correct return type for `BrowserKitAssertionsTrait::getClient()` method.
+* Provides configurable return type resolution for methods that internally use Messenger `HandleTrait`.
 * Notifies you when you try to get an unregistered service from the container.
 * Notifies you when you try to get a private service from the container.
 * Notifies you when you access undefined console command arguments or options.
@@ -179,4 +180,95 @@ Call the new env in your `console-application.php`:
 
 ```php
 $kernel = new \App\Kernel('phpstan_env', (bool) $_SERVER['APP_DEBUG']);
+```
+
+## Messenger HandleTrait Wrappers
+
+The extension provides advanced type inference for methods that internally use Symfony Messenger's `HandleTrait`. This feature is particularly useful for query bus implementations (in CQRS pattern) that use/wrap the `HandleTrait::handle()` method.
+
+### Configuration
+
+```neon
+parameters:
+    symfony:
+        messenger:
+            handleTraitWrappers:
+                - App\Bus\QueryBus::dispatch
+                - App\Bus\QueryBus::execute
+                - App\Bus\QueryBusInterface::dispatch
+```
+
+### Message Handlers
+
+```php
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+// Product handler that returns Product
+#[AsMessageHandler]
+class GetProductQueryHandler
+{
+    public function __invoke(GetProductQuery $query): Product
+    {
+        return $this->productRepository->get($query->productId);
+    }
+}
+```
+
+### PHP Examples
+
+```php
+use Symfony\Component\Messenger\HandleTrait;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+// Basic query bus implementation
+class QueryBus
+{
+    use HandleTrait;
+
+    public function __construct(MessageBusInterface $messageBus)
+    {
+        $this->messageBus = $messageBus;
+    }
+
+    public function dispatch(object $query): mixed
+    {
+        return $this->handle($query); // Return type will be inferred
+    }
+
+    // Multiple methods per class example
+    public function execute(object $message): mixed
+    {
+        return $this->handle($message);
+    }
+}
+
+// Interface-based configuration example
+interface QueryBusInterface
+{
+    public function dispatch(object $query): mixed;
+}
+
+class QueryBusWithInterface implements QueryBusInterface
+{
+    use HandleTrait;
+
+    public function __construct(MessageBusInterface $queryBus)
+    {
+        $this->messageBus = $queryBus;
+    }
+
+    public function dispatch(object $query): mixed
+    {
+        return $this->handle($query);
+    }
+}
+
+// Usage examples with proper type inference
+$query = new GetProductQuery($productId);
+$queryBus = new QueryBus($messageBus);
+$queryBusWithInterface = new QueryBusWithInterface($messageBus);
+
+$product = $queryBus->dispatch($query); // Returns: Product
+$product2 = $queryBus->execute($query); // Returns: Product
+$product3 = $queryBusWithInterface->dispatch($query); // Returns: Product
 ```

--- a/extension.neon
+++ b/extension.neon
@@ -8,6 +8,11 @@ parameters:
 		containerXmlPath: null
 		constantHassers: true
 		consoleApplicationLoader: null
+		messenger:
+			handleTraitWrappers:
+				# move that params to tests only
+				- MessengerHandleTrait\QueryBus::dispatch
+				- MessengerHandleTrait\QueryBus2::dispatch
 	stubFiles:
 		- stubs/Psr/Cache/CacheException.stub
 		- stubs/Psr/Cache/CacheItemInterface.stub
@@ -96,6 +101,9 @@ parametersSchema:
 		containerXmlPath: schema(string(), nullable())
 		constantHassers: bool()
 		consoleApplicationLoader: schema(string(), nullable())
+		messenger: structure([
+			handleTraitWrappers: listOf(string())
+		])
 	])
 
 services:
@@ -201,6 +209,11 @@ services:
 	# Messenger HandleTrait::handle() return type
 	-
 		class: PHPStan\Type\Symfony\MessengerHandleTraitReturnTypeExtension
+		tags: [phpstan.broker.expressionTypeResolverExtension]
+
+	# Messenger HandleTrait wrappers return type
+	-
+		class: PHPStan\Type\Symfony\MessengerHandleTraitWrapperReturnTypeExtension
 		tags: [phpstan.broker.expressionTypeResolverExtension]
 
 	# InputInterface::getArgument() return type

--- a/extension.neon
+++ b/extension.neon
@@ -9,11 +9,7 @@ parameters:
 		constantHassers: true
 		consoleApplicationLoader: null
 		messenger:
-			handleTraitWrappers:
-				# todo move that params to tests only
-				- MessengerHandleTrait\QueryBus::dispatch
-				- MessengerHandleTrait\QueryBus::dispatch2
-				- MessengerHandleTrait\QueryBusInterface::dispatch
+			handleTraitWrappers: []
 	stubFiles:
 		- stubs/Psr/Cache/CacheException.stub
 		- stubs/Psr/Cache/CacheItemInterface.stub

--- a/extension.neon
+++ b/extension.neon
@@ -212,6 +212,8 @@ services:
 	-
 		class: PHPStan\Type\Symfony\MessengerHandleTraitWrapperReturnTypeExtension
 		tags: [phpstan.broker.expressionTypeResolverExtension]
+		arguments:
+			messenger: %symfony.messenger%
 
 	# InputInterface::getArgument() return type
 	-

--- a/extension.neon
+++ b/extension.neon
@@ -10,9 +10,10 @@ parameters:
 		consoleApplicationLoader: null
 		messenger:
 			handleTraitWrappers:
-				# move that params to tests only
+				# todo move that params to tests only
 				- MessengerHandleTrait\QueryBus::dispatch
-				- MessengerHandleTrait\QueryBus2::dispatch
+				- MessengerHandleTrait\QueryBus::dispatch2
+				- MessengerHandleTrait\QueryBusInterface::dispatch
 	stubFiles:
 		- stubs/Psr/Cache/CacheException.stub
 		- stubs/Psr/Cache/CacheItemInterface.stub

--- a/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
+++ b/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
@@ -11,6 +11,7 @@ use PHPStan\Symfony\MessageMap;
 use PHPStan\Symfony\MessageMapFactory;
 use PHPStan\Type\ExpressionTypeResolverExtension;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use function count;
 use function in_array;
 use function is_null;
@@ -59,16 +60,23 @@ final class MessengerHandleTraitWrapperReturnTypeExtension implements Expression
 		$arg = $args[0]->value;
 		$argClassNames = $scope->getType($arg)->getObjectClassNames();
 
-		if (count($argClassNames) === 1) {
-			$messageMap = $this->getMessageMap();
-			$returnType = $messageMap->getTypeForClass($argClassNames[0]);
-
-			if (!is_null($returnType)) {
-				return $returnType;
-			}
+		if (count($argClassNames) === 0) {
+			return null;
 		}
 
-		return null;
+		$returnTypes = [];
+		foreach ($argClassNames as $argClassName) {
+			$messageMap = $this->getMessageMap();
+			$returnType = $messageMap->getTypeForClass($argClassName);
+
+			if (is_null($returnType)) {
+				return null;
+			}
+
+			$returnTypes[] = $returnType;
+		}
+
+		return TypeCombinator::union(...$returnTypes);
 	}
 
 	/**
@@ -88,11 +96,21 @@ final class MessengerHandleTraitWrapperReturnTypeExtension implements Expression
 		$varType = $scope->getType($expr->var);
 		$classNames = $varType->getObjectClassNames();
 
-		if (count($classNames) !== 1) {
+		if (count($classNames) === 0) {
 			return false;
 		}
 
-		$className = $classNames[0];
+		foreach ($classNames as $className) {
+			if (!$this->isClassMethodSupported($className, $methodName)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private function isClassMethodSupported(string $className, string $methodName): bool
+	{
 		$classMethodCombination = $className . '::' . $methodName;
 
 		// Check if this exact class::method combination is configured

--- a/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
+++ b/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
@@ -6,6 +6,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Symfony\MessageMap;
 use PHPStan\Symfony\MessageMapFactory;
 use PHPStan\Type\ExpressionTypeResolverExtension;
@@ -18,7 +19,7 @@ use function is_null;
  * Configurable extension for resolving return types of methods that internally use HandleTrait.
  *
  * Configured via PHPStan parameters under symfony.messenger.handleTraitWrappers with
- * "Class::method" patterns, e.g.:
+ * "class::method" patterns, e.g.:
  * - App\Bus\QueryBus::dispatch
  * - App\Bus\QueryBus::query
  * - App\Bus\CommandBus::execute
@@ -34,11 +35,14 @@ final class MessengerHandleTraitWrapperReturnTypeExtension implements Expression
 	/** @var array<string> */
 	private array $wrappers;
 
+	private ReflectionProvider $reflectionProvider;
+
 	/** @param array{handleTraitWrappers: array<string>}|null $messenger */
-	public function __construct(MessageMapFactory $messageMapFactory, ?array $messenger)
+	public function __construct(MessageMapFactory $messageMapFactory, ?array $messenger, ReflectionProvider $reflectionProvider)
 	{
 		$this->messageMapFactory = $messageMapFactory;
 		$this->wrappers = $messenger['handleTraitWrappers'] ?? [];
+		$this->reflectionProvider = $reflectionProvider;
 	}
 
 	public function getType(Expr $expr, Scope $scope): ?Type
@@ -91,8 +95,23 @@ final class MessengerHandleTraitWrapperReturnTypeExtension implements Expression
 		$className = $classNames[0];
 		$classMethodCombination = $className . '::' . $methodName;
 
-		// Check if this class::method combination is configured
-		return in_array($classMethodCombination, $this->wrappers, true);
+		// Check if this exact class::method combination is configured
+		if (in_array($classMethodCombination, $this->wrappers, true)) {
+			return true;
+		}
+
+		// Check if any interface implemented by this class::method is configured
+		if ($this->reflectionProvider->hasClass($className)) {
+			$classReflection = $this->reflectionProvider->getClass($className);
+			foreach ($classReflection->getInterfaces() as $interface) {
+				$interfaceMethodCombination = $interface->getName() . '::' . $methodName;
+				if (in_array($interfaceMethodCombination, $this->wrappers, true)) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	private function getMessageMap(): MessageMap

--- a/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
+++ b/src/Type/Symfony/MessengerHandleTraitWrapperReturnTypeExtension.php
@@ -1,0 +1,107 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Symfony\MessageMap;
+use PHPStan\Symfony\MessageMapFactory;
+use PHPStan\Type\ExpressionTypeResolverExtension;
+use PHPStan\Type\Type;
+use function count;
+use function in_array;
+use function is_null;
+
+/**
+ * Configurable extension for resolving return types of methods that internally use HandleTrait.
+ *
+ * Configured via PHPStan parameters under symfony.messenger.handleTraitWrappers with
+ * "Class::method" patterns, e.g.:
+ * - App\Bus\QueryBus::dispatch
+ * - App\Bus\QueryBus::query
+ * - App\Bus\CommandBus::execute
+ * - App\Bus\CommandBus::handle
+ */
+final class MessengerHandleTraitWrapperReturnTypeExtension implements ExpressionTypeResolverExtension
+{
+
+	private MessageMapFactory $messageMapFactory;
+
+	private ?MessageMap $messageMap = null;
+
+	/** @var array<string> */
+	private array $wrappers;
+
+	/** @param array{handleTraitWrappers: array<string>}|null $messenger */
+	public function __construct(MessageMapFactory $messageMapFactory, ?array $messenger)
+	{
+		$this->messageMapFactory = $messageMapFactory;
+		$this->wrappers = $messenger['handleTraitWrappers'] ?? [];
+	}
+
+	public function getType(Expr $expr, Scope $scope): ?Type
+	{
+		if (!$this->isSupported($expr, $scope)) {
+			return null;
+		}
+
+		$args = $expr->getArgs();
+		if (count($args) !== 1) {
+			return null;
+		}
+
+		$arg = $args[0]->value;
+		$argClassNames = $scope->getType($arg)->getObjectClassNames();
+
+		if (count($argClassNames) === 1) {
+			$messageMap = $this->getMessageMap();
+			$returnType = $messageMap->getTypeForClass($argClassNames[0]);
+
+			if (!is_null($returnType)) {
+				return $returnType;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * @phpstan-assert-if-true =MethodCall $expr
+	 */
+	private function isSupported(Expr $expr, Scope $scope): bool
+	{
+		if ($this->wrappers === []) {
+			return false;
+		}
+
+		if (!($expr instanceof MethodCall) || !($expr->name instanceof Identifier)) {
+			return false;
+		}
+
+		$methodName = $expr->name->name;
+		$varType = $scope->getType($expr->var);
+		$classNames = $varType->getObjectClassNames();
+
+		if (count($classNames) !== 1) {
+			return false;
+		}
+
+		$className = $classNames[0];
+		$classMethodCombination = $className . '::' . $methodName;
+
+		// Check if this class::method combination is configured
+		return in_array($classMethodCombination, $this->wrappers, true);
+	}
+
+	private function getMessageMap(): MessageMap
+	{
+		if ($this->messageMap === null) {
+			$this->messageMap = $this->messageMapFactory->create();
+		}
+
+		return $this->messageMap;
+	}
+
+}

--- a/tests/Type/Symfony/data/messenger_handle_trait.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait.php
@@ -62,9 +62,18 @@ class QueryBus {
     {
         return $this->handle($query);
     }
+
+	public function dispatch2(object $query): mixed
+	{
+		return $this->handle($query);
+	}
 }
 
-class QueryBus2 {
+interface QueryBusInterface {
+	public function dispatch(object $query): mixed;
+}
+
+class QueryBusWithInterface implements QueryBusInterface {
 	use HandleTrait;
 
 	public function dispatch(object $query): mixed
@@ -87,11 +96,14 @@ class Controller {
 
         assertType(TaggedResult::class, $queryBus->dispatch(new TaggedQuery()));
 
+		assertType(RegularQueryResult::class, $queryBus->dispatch2(new RegularQuery()));
+
+		$queryBusWithInterface = new QueryBusWithInterface();
+
+		assertType(RegularQueryResult::class, $queryBusWithInterface->dispatch(new RegularQuery()));
+
         // HandleTrait will throw exception in fact due to multiple handle methods/handlers per single query
         assertType('mixed', $queryBus->dispatch(new MultiHandlesForInTheSameHandlerQuery()));
         assertType('mixed', $queryBus->dispatch(new MultiHandlersForTheSameMessageQuery()));
-
-		$queryBus2 = new QueryBus2();
-		assertType(TaggedResult::class, $queryBus2->dispatch(new TaggedQuery()));
     }
 }

--- a/tests/Type/Symfony/data/messenger_handle_trait.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait.php
@@ -50,6 +50,9 @@ class HandleTraitClass {
 
         assertType(TaggedResult::class, $this->handle(new TaggedQuery()));
 
+		$randomQuery = rand(0, 1) ? new RegularQuery() : new TaggedQuery();
+		assertType(RegularQueryResult::class . '|' . TaggedResult::class, $this->handle($randomQuery));
+
         // HandleTrait will throw exception in fact due to multiple handle methods/handlers per single query
         assertType('mixed', $this->handle(new MultiHandlersForTheSameMessageQuery()));
     }
@@ -94,6 +97,9 @@ class Controller {
         assertType('float', $queryBus->dispatch(new FloatQuery()));
         assertType('string', $queryBus->dispatch(new StringQuery()));
 
+		$randomQuery = rand(0, 1) ? new IntQuery() : new StringQuery();
+		assertType('int|string', $queryBus->dispatch($randomQuery));
+
         assertType(TaggedResult::class, $queryBus->dispatch(new TaggedQuery()));
 
 		assertType(RegularQueryResult::class, $queryBus->dispatch2(new RegularQuery()));
@@ -101,6 +107,9 @@ class Controller {
 		$queryBusWithInterface = new QueryBusWithInterface();
 
 		assertType(RegularQueryResult::class, $queryBusWithInterface->dispatch(new RegularQuery()));
+
+		$randomQueryBus = rand(0, 1) ? $queryBus : $queryBusWithInterface;
+		assertType(RegularQueryResult::class, $randomQueryBus->dispatch(new RegularQuery()));
 
         // HandleTrait will throw exception in fact due to multiple handle methods/handlers per single query
         assertType('mixed', $queryBus->dispatch(new MultiHandlesForInTheSameHandlerQuery()));

--- a/tests/Type/Symfony/data/messenger_handle_trait.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait.php
@@ -54,3 +54,32 @@ class HandleTraitClass {
         assertType('mixed', $this->handle(new MultiHandlersForTheSameMessageQuery()));
     }
 }
+
+class QueryBus {
+    use HandleTrait;
+
+    public function dispatch(object $query): mixed
+    {
+        return $this->handle($query);
+    }
+}
+
+class Controller {
+    public function action()
+    {
+        $queryBus = new QueryBus();
+
+        assertType(RegularQueryResult::class, $queryBus->dispatch(new RegularQuery()));
+
+        assertType('bool', $queryBus->dispatch(new BooleanQuery()));
+        assertType('int', $queryBus->dispatch(new IntQuery()));
+        assertType('float', $queryBus->dispatch(new FloatQuery()));
+        assertType('string', $queryBus->dispatch(new StringQuery()));
+
+        assertType(TaggedResult::class, $queryBus->dispatch(new TaggedQuery()));
+
+        // HandleTrait will throw exception in fact due to multiple handle methods/handlers per single query
+        assertType('mixed', $queryBus->dispatch(new MultiHandlesForInTheSameHandlerQuery()));
+        assertType('mixed', $queryBus->dispatch(new MultiHandlersForTheSameMessageQuery()));
+    }
+}

--- a/tests/Type/Symfony/data/messenger_handle_trait.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait.php
@@ -61,25 +61,25 @@ class HandleTraitClass {
 class QueryBus {
     use HandleTrait;
 
-    public function dispatch(object $query): mixed
+    public function dispatch(object $query)
     {
         return $this->handle($query);
     }
 
-	public function dispatch2(object $query): mixed
+	public function dispatch2(object $query)
 	{
 		return $this->handle($query);
 	}
 }
 
 interface QueryBusInterface {
-	public function dispatch(object $query): mixed;
+	public function dispatch(object $query);
 }
 
 class QueryBusWithInterface implements QueryBusInterface {
 	use HandleTrait;
 
-	public function dispatch(object $query): mixed
+	public function dispatch(object $query)
 	{
 		return $this->handle($query);
 	}

--- a/tests/Type/Symfony/data/messenger_handle_trait.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait.php
@@ -64,6 +64,15 @@ class QueryBus {
     }
 }
 
+class QueryBus2 {
+	use HandleTrait;
+
+	public function dispatch(object $query): mixed
+	{
+		return $this->handle($query);
+	}
+}
+
 class Controller {
     public function action()
     {
@@ -81,5 +90,8 @@ class Controller {
         // HandleTrait will throw exception in fact due to multiple handle methods/handlers per single query
         assertType('mixed', $queryBus->dispatch(new MultiHandlesForInTheSameHandlerQuery()));
         assertType('mixed', $queryBus->dispatch(new MultiHandlersForTheSameMessageQuery()));
+
+		$queryBus2 = new QueryBus2();
+		assertType(TaggedResult::class, $queryBus2->dispatch(new TaggedQuery()));
     }
 }

--- a/tests/Type/Symfony/data/messenger_handle_trait_with_subscriber.php
+++ b/tests/Type/Symfony/data/messenger_handle_trait_with_subscriber.php
@@ -56,7 +56,7 @@ class MultiHandlesForInTheSameHandler implements MessageSubscriberInterface
     }
 }
 
-class HandleTraitClass {
+class HandleTraitClassWithSubscriber {
     use HandleTrait;
 
     public function __invoke()

--- a/tests/Type/Symfony/extension-test.neon
+++ b/tests/Type/Symfony/extension-test.neon
@@ -2,3 +2,8 @@ parameters:
 	symfony:
 		consoleApplicationLoader: console_application_loader.php
 		containerXmlPath: container.xml
+		messenger:
+			handleTraitWrappers:
+				- MessengerHandleTrait\QueryBus::dispatch
+				- MessengerHandleTrait\QueryBus::dispatch2
+				- MessengerHandleTrait\QueryBusInterface::dispatch


### PR DESCRIPTION
This PR goal is to determine correct result typing for QueryBus kind of classes which uses SF messenger HandleTrait internally and simply return its results.