### PR TITLE
Synchronize the EventSubscriberInterface with the upstream type

### DIFF
--- a/stubs/Symfony/Component/EventDispatcher/EventSubscriberInterface.stub
+++ b/stubs/Symfony/Component/EventDispatcher/EventSubscriberInterface.stub
@@ -5,7 +5,7 @@ namespace Symfony\Component\EventDispatcher;
 interface EventSubscriberInterface
 {
     /**
-     * @return array<string, string|array<string, int>|array<int, string|array<string, int>|array<int, string>>>
+     * @return array<string, string|array{0: string, 1: int}|list<array{0: string, 1?: int}>>
      */
     public static function getSubscribedEvents();
 }


### PR DESCRIPTION
As of Symfony 5.4, Symfony ships a precise type for this interface but the stub overrides it.