### PR TITLE
Fix "Possibly invalid array key type string|null."

### DIFF
--- a/src/Symfony/XmlServiceMapFactory.php
+++ b/src/Symfony/XmlServiceMapFactory.php
@@ -77,7 +77,7 @@ final class XmlServiceMapFactory implements ServiceMapFactory
 		}
 		foreach ($aliases as $service) {
 			$alias = $service->getAlias();
-			if ($alias !== null && !isset($services[$alias])) {
+			if ($alias === null || !isset($services[$alias])) {
 				continue;
 			}
 			$id = $service->getId();


### PR DESCRIPTION
fixes build error

```
  ------ ---------------------------------------------- 
  Line   src/Symfony/XmlServiceMapFactory.php          
 ------ ---------------------------------------------- 
  86     Possibly invalid array key type string|null.  
         🪪  offsetAccess.invalidOffset                
 ------ ---------------------------------------------- 
 ```