### PR TITLE
Support stringNode in Config component

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -254,7 +254,7 @@ services:
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 		arguments:
 		    className: Symfony\Component\Config\Definition\Builder\NodeBuilder
-		    methods: [arrayNode, scalarNode, booleanNode, integerNode, floatNode, enumNode, variableNode]
+		    methods: [arrayNode, scalarNode, stringNode, booleanNode, integerNode, floatNode, enumNode, variableNode]
 
 	# NodeBuilder::end() return type
 	-

--- a/src/Type/Symfony/Config/ArrayNodeDefinitionPrototypeDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/Config/ArrayNodeDefinitionPrototypeDynamicReturnTypeExtension.php
@@ -19,6 +19,7 @@ final class ArrayNodeDefinitionPrototypeDynamicReturnTypeExtension implements Dy
 	private const PROTOTYPE_METHODS = [
 		'arrayPrototype',
 		'scalarPrototype',
+		'stringPrototype',
 		'booleanPrototype',
 		'integerPrototype',
 		'floatPrototype',
@@ -29,6 +30,7 @@ final class ArrayNodeDefinitionPrototypeDynamicReturnTypeExtension implements Dy
 	private const MAPPING = [
 		'variable' => 'Symfony\Component\Config\Definition\Builder\VariableNodeDefinition',
 		'scalar' => 'Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition',
+		'string' => 'Symfony\Component\Config\Definition\Builder\StringNodeDefinition',
 		'boolean' => 'Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition',
 		'integer' => 'Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition',
 		'float' => 'Symfony\Component\Config\Definition\Builder\FloatNodeDefinition',

--- a/src/Type/Symfony/Config/TreeBuilderDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/Config/TreeBuilderDynamicReturnTypeExtension.php
@@ -18,6 +18,7 @@ final class TreeBuilderDynamicReturnTypeExtension implements DynamicStaticMethod
 	private const MAPPING = [
 		'variable' => 'Symfony\Component\Config\Definition\Builder\VariableNodeDefinition',
 		'scalar' => 'Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition',
+		'string' => 'Symfony\Component\Config\Definition\Builder\StringNodeDefinition',
 		'boolean' => 'Symfony\Component\Config\Definition\Builder\BooleanNodeDefinition',
 		'integer' => 'Symfony\Component\Config\Definition\Builder\IntegerNodeDefinition',
 		'float' => 'Symfony\Component\Config\Definition\Builder\FloatNodeDefinition',

--- a/tests/Type/Symfony/data/tree_builder.php
+++ b/tests/Type/Symfony/data/tree_builder.php
@@ -154,6 +154,13 @@ assertType('Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition', $
 assertType('Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition', $scalarRootNode->defaultValue("default"));
 assertType('Symfony\Component\Config\Definition\Builder\TreeBuilder', $scalarRootNode->defaultValue("default")->end());
 
+$stringTreeBuilder = new TreeBuilder('my_tree', 'string');
+$stringRootNode = $stringTreeBuilder->getRootNode();
+
+assertType('Symfony\Component\Config\Definition\Builder\StringNodeDefinition', $stringRootNode);
+assertType('Symfony\Component\Config\Definition\Builder\StringNodeDefinition', $stringRootNode->defaultValue("default"));
+assertType('Symfony\Component\Config\Definition\Builder\TreeBuilder', $stringRootNode->defaultValue("default")->end());
+
 $booleanTreeBuilder = new TreeBuilder('my_tree', 'boolean');
 $booleanRootNode = $booleanTreeBuilder->getRootNode();
 


### PR DESCRIPTION
Symfony 7.2 added `>stringNode()` method to `NodeBuilder`.