### PR TITLE
Fix Serializer return type for arrays of primitives

### DIFF
--- a/src/Type/Symfony/SerializerDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/SerializerDynamicReturnTypeExtension.php
@@ -6,9 +6,13 @@ use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
 use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
 use PHPStan\Type\Type;
 use PHPStan\Type\TypeCombinator;
 use function count;
@@ -65,6 +69,17 @@ class SerializerDynamicReturnTypeExtension implements DynamicMethodReturnTypeExt
 		if (substr($objectName, -2) === '[]') {
 			// The key type is determined by the data
 			return new ArrayType(new MixedType(false), $this->getType(substr($objectName, 0, -2)));
+		}
+
+		switch ($objectName) {
+			case 'int':
+				return new IntegerType();
+			case 'string':
+				return new StringType();
+			case 'bool':
+				return new BooleanType();
+			case 'float':
+				return new FloatType();
 		}
 
 		return new ObjectType($objectName);

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -54,6 +54,7 @@ class ExtensionTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/serializer.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/serializer_primitives.php');
 
 		if (class_exists('Symfony\Component\HttpFoundation\InputBag')) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/input_bag_from_request.php');

--- a/tests/Type/Symfony/data/serializer_primitives.php
+++ b/tests/Type/Symfony/data/serializer_primitives.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+use function PHPStan\Testing\assertType;
+
+$serializer = new \Symfony\Component\Serializer\Serializer();
+
+assertType('int', $serializer->deserialize('...', 'int[]', 'json')[0] + 1);
+assertType('string', $serializer->deserialize('...', 'string[]', 'json')[0] . '');
+assertType('bool', !$serializer->deserialize('...', 'bool[]', 'json')[0]);
+assertType('float', $serializer->deserialize('...', 'float[]', 'json')[0] + 1.0);
+assertType('int', $serializer->deserialize('...', 'int[][]', 'json')[0][0] + 1);
+


### PR DESCRIPTION
Fixes type inference for primitive scalar types (`int`, `string`, `bool`, `float`) when used with `Serializer::deserialize()`.

Currently, the extension wraps all base types in `ObjectType`. This means `int[]` is incorrectly inferred as an array of objects named "int" rather than scalar integers, causing false positives during arithmetic operations.