### PR TITLE
Fix Docblock for InputBag

### DIFF
--- a/stubs/Symfony/Component/HttpFoundation/InputBag.stub
+++ b/stubs/Symfony/Component/HttpFoundation/InputBag.stub
@@ -3,14 +3,15 @@
 namespace Symfony\Component\HttpFoundation;
 
 /**
- * @template TValue of string|int|float|bool
+ * @template TInput of string|int|float|bool|null
  */
 final class InputBag extends ParameterBag
 {
 
 	/**
-	 * @param TValue|null $default
-	 * @return TValue|null
+     * @template TDefault of string|int|float|bool|null
+     * @param TDefault $default
+     * @return TDefault|TInput
 	 */
 	public function get(string $key, $default = null)
 	{


### PR DESCRIPTION
Fixes #453

The doc block was copied from the original class: https://github.com/symfony/symfony/pull/61698