### PR TITLE
Add TraceableMessageBus stub with typed getDispatchedMessages()

### DIFF
--- a/src/Stubs/Symfony/StubFilesExtensionLoader.php
+++ b/src/Stubs/Symfony/StubFilesExtensionLoader.php
@@ -93,6 +93,10 @@ class StubFilesExtensionLoader implements StubFilesExtension
 			$files[] = $stubsDir . '/Symfony/Component/Messenger/StampInterface.stub';
 		}
 
+		if ($this->isInstalledVersionBelow('symfony/messenger', '8.1.0.0')) {
+			$files[] = $stubsDir . '/Symfony/Component/Messenger/TraceableMessageBus.stub';
+		}
+
 		if ($this->isInstalledVersionBelow('symfony/process', '5.4.0.0')) {
 			$files[] = $stubsDir . '/Symfony/Component/Process/Exception/LogicException.stub';
 			$files[] = $stubsDir . '/Symfony/Component/Process/Process.stub';

--- a/stubs/Symfony/Component/Messenger/TraceableMessageBus.stub
+++ b/stubs/Symfony/Component/Messenger/TraceableMessageBus.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symfony\Component\Messenger;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+class TraceableMessageBus
+{
+
+    /**
+     * @return list<array{
+     *     stamps: list<StampInterface>,
+     *     message: object,
+     *     caller: array{name: string, file: string|null, line: int|null},
+     *     callTime: float,
+     *     exception?: \Throwable,
+     *     stamps_after_dispatch: list<StampInterface>,
+     * }>
+     */
+    public function getDispatchedMessages(): array
+    {
+    }
+
+}

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -22,6 +22,8 @@ class ExtensionTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/envelope_all.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/traceable_message_bus.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/header_bag_get.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/response_header_bag_get_cookies.php');
 

--- a/tests/Type/Symfony/data/traceable_message_bus.php
+++ b/tests/Type/Symfony/data/traceable_message_bus.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+use Symfony\Component\Messenger\TraceableMessageBus;
+use function PHPStan\Testing\assertType;
+
+$bus = new TraceableMessageBus(new class implements \Symfony\Component\Messenger\MessageBusInterface {
+	public function dispatch(object $message, array $stamps = []): \Symfony\Component\Messenger\Envelope
+	{
+		return new \Symfony\Component\Messenger\Envelope($message);
+	}
+});
+
+$messages = $bus->getDispatchedMessages();
+assertType('list<array{stamps: list<Symfony\Component\Messenger\Stamp\StampInterface>, message: object, caller: array{name: string, file: string|null, line: int|null}, callTime: float, exception?: Throwable, stamps_after_dispatch: list<Symfony\Component\Messenger\Stamp\StampInterface>}>', $messages);


### PR DESCRIPTION
This adds stubs for the TraceableMessageBus to make it easier to write tests using this class.