### PR TITLE
Use external file dependencies instead of ResultCacheMetaExtension

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -137,16 +137,16 @@ services:
 
 	# ControllerTrait::get()/has() return type
 	-
-		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ContainerInterface, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ContainerInterface, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
-		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Psr\Container\ContainerInterface, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Psr\Container\ContainerInterface, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
-		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\Controller, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\Controller, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
-		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\AbstractController, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ServiceDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\AbstractController, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
 	# ControllerTrait::has() type specification
@@ -314,20 +314,20 @@ services:
 
 	# ParameterBagInterface::get()/has() return type
 	-
-		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface, 'get', 'has', %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface, 'get', 'has', %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
 	# ContainerInterface::getParameter()/hasParameter() return type
 	-
-		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ContainerInterface, 'getParameter', 'hasParameter', %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Component\DependencyInjection\ContainerInterface, 'getParameter', 'hasParameter', %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
 	# (Abstract)Controller::getParameter() return type
 	-
-		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\AbstractController, 'getParameter', null, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\AbstractController, 'getParameter', null, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
-		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\Controller, 'getParameter', null, %symfony.constantHassers%)
+		factory: PHPStan\Type\Symfony\ParameterDynamicReturnTypeExtension(Symfony\Bundle\FrameworkBundle\Controller\Controller, 'getParameter', null, %symfony.constantHassers%, containerXmlPath: %symfony.containerXmlPath%)
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 	-
 		class: PHPStan\Symfony\InputBagStubFilesExtension
@@ -375,7 +375,6 @@ services:
 		factory: PHPStan\Type\Symfony\ExtensionGetConfigurationReturnTypeExtension
 		tags: [phpstan.broker.dynamicMethodReturnTypeExtension]
 
-	-
-		class: PHPStan\Symfony\SymfonyContainerResultCacheMetaExtension
-		tags:
-			- phpstan.resultCacheMetaExtension
+	# SymfonyContainerResultCacheMetaExtension removed: replaced by external file
+	# dependency tracking which provides incremental (per-file) cache invalidation
+	# instead of full cache invalidation when the container XML changes.

--- a/rules.neon
+++ b/rules.neon
@@ -1,8 +1,18 @@
 rules:
-	- PHPStan\Rules\Symfony\ContainerInterfacePrivateServiceRule
-	- PHPStan\Rules\Symfony\ContainerInterfaceUnknownServiceRule
 	- PHPStan\Rules\Symfony\UndefinedArgumentRule
 	- PHPStan\Rules\Symfony\InvalidArgumentDefaultValueRule
 	- PHPStan\Rules\Symfony\UndefinedOptionRule
 	- PHPStan\Rules\Symfony\InvalidOptionDefaultValueRule
+
+services:
+	-
+		class: PHPStan\Rules\Symfony\ContainerInterfacePrivateServiceRule
+		arguments:
+			containerXmlPath: %symfony.containerXmlPath%
+		tags: [phpstan.rules.rule]
+	-
+		class: PHPStan\Rules\Symfony\ContainerInterfaceUnknownServiceRule
+		arguments:
+			containerXmlPath: %symfony.containerXmlPath%
+		tags: [phpstan.rules.rule]
 

--- a/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfacePrivateServiceRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Symfony;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -21,9 +22,19 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 
 	private ServiceMap $serviceMap;
 
-	public function __construct(ServiceMap $symfonyServiceMap)
+	private ?string $containerXmlPath;
+
+	private ?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar;
+
+	public function __construct(
+		ServiceMap $symfonyServiceMap,
+		?string $containerXmlPath = null,
+		?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar = null,
+	)
 	{
 		$this->serviceMap = $symfonyServiceMap;
+		$this->containerXmlPath = $containerXmlPath;
+		$this->externalFileDependencyRegistrar = $externalFileDependencyRegistrar;
 	}
 
 	public function getNodeType(): string
@@ -66,6 +77,9 @@ final class ContainerInterfacePrivateServiceRule implements Rule
 
 		$serviceId = $this->serviceMap::getServiceIdFromNode($node->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
+			if ($this->containerXmlPath !== null && $this->externalFileDependencyRegistrar !== null) {
+				$this->externalFileDependencyRegistrar->add($this->containerXmlPath);
+			}
 			$service = $this->serviceMap->getService($serviceId);
 			if ($service !== null && !$service->isPublic()) {
 				return [

--- a/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
@@ -4,6 +4,7 @@ namespace PHPStan\Rules\Symfony;
 
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\Printer\Printer;
 use PHPStan\Rules\Rule;
@@ -23,10 +24,21 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 
 	private Printer $printer;
 
-	public function __construct(ServiceMap $symfonyServiceMap, Printer $printer)
+	private ?string $containerXmlPath;
+
+	private ?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar;
+
+	public function __construct(
+		ServiceMap $symfonyServiceMap,
+		Printer $printer,
+		?string $containerXmlPath = null,
+		?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar = null,
+	)
 	{
 		$this->serviceMap = $symfonyServiceMap;
 		$this->printer = $printer;
+		$this->containerXmlPath = $containerXmlPath;
+		$this->externalFileDependencyRegistrar = $externalFileDependencyRegistrar;
 	}
 
 	public function getNodeType(): string
@@ -65,6 +77,9 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 
 		$serviceId = $this->serviceMap::getServiceIdFromNode($node->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
+			if ($this->containerXmlPath !== null && $this->externalFileDependencyRegistrar !== null) {
+				$this->externalFileDependencyRegistrar->add($this->containerXmlPath);
+			}
 			$service = $this->serviceMap->getService($serviceId);
 			$serviceIdType = $scope->getType($node->getArgs()[0]->value);
 			if ($service === null && !$scope->getType(Helper::createMarkerNode($node->var, $serviceIdType, $this->printer))->equals($serviceIdType)) {

--- a/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ParameterDynamicReturnTypeExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Symfony;
 
 use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Scope;
 use PHPStan\PhpDoc\TypeStringResolver;
 use PHPStan\Reflection\MethodReflection;
@@ -54,6 +55,10 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 
 	private TypeStringResolver $typeStringResolver;
 
+	private ?string $containerXmlPath;
+
+	private ?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar;
+
 	/**
 	 * @param class-string $className
 	 */
@@ -63,7 +68,9 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 		?string $methodHas,
 		bool $constantHassers,
 		ParameterMap $symfonyParameterMap,
-		TypeStringResolver $typeStringResolver
+		TypeStringResolver $typeStringResolver,
+		?string $containerXmlPath = null,
+		?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar = null,
 	)
 	{
 		$this->className = $className;
@@ -72,6 +79,8 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 		$this->constantHassers = $constantHassers;
 		$this->parameterMap = $symfonyParameterMap;
 		$this->typeStringResolver = $typeStringResolver;
+		$this->containerXmlPath = $containerXmlPath;
+		$this->externalFileDependencyRegistrar = $externalFileDependencyRegistrar;
 	}
 
 	public function getClass(): string
@@ -121,6 +130,8 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 		if ($parameterKeys === []) {
 			return $defaultReturnType;
 		}
+
+		$this->registerExternalDependency();
 
 		$returnTypes = [];
 		foreach ($parameterKeys as $parameterKey) {
@@ -203,6 +214,13 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 		});
 	}
 
+	private function registerExternalDependency(): void
+	{
+		if ($this->containerXmlPath !== null && $this->externalFileDependencyRegistrar !== null) {
+			$this->externalFileDependencyRegistrar->add($this->containerXmlPath);
+		}
+	}
+
 	private function getHasTypeFromMethodCall(
 		MethodReflection $methodReflection,
 		MethodCall $methodCall,
@@ -217,6 +235,8 @@ final class ParameterDynamicReturnTypeExtension implements DynamicMethodReturnTy
 		if ($parameterKeys === []) {
 			return null;
 		}
+
+		$this->registerExternalDependency();
 
 		$has = null;
 		foreach ($parameterKeys as $parameterKey) {

--- a/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
@@ -3,6 +3,7 @@
 namespace PHPStan\Type\Symfony;
 
 use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\ExternalFileDependencyRegistrar;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\ShouldNotHappenException;
@@ -30,6 +31,10 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 	private ParameterMap $parameterMap;
 
+	private ?string $containerXmlPath;
+
+	private ?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar;
+
 	private ?ParameterBag $parameterBag = null;
 
 	/**
@@ -39,13 +44,17 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 		string $className,
 		bool $constantHassers,
 		ServiceMap $symfonyServiceMap,
-		ParameterMap $symfonyParameterMap
+		ParameterMap $symfonyParameterMap,
+		?string $containerXmlPath = null,
+		?ExternalFileDependencyRegistrar $externalFileDependencyRegistrar = null,
 	)
 	{
 		$this->className = $className;
 		$this->constantHassers = $constantHassers;
 		$this->serviceMap = $symfonyServiceMap;
 		$this->parameterMap = $symfonyParameterMap;
+		$this->containerXmlPath = $containerXmlPath;
+		$this->externalFileDependencyRegistrar = $externalFileDependencyRegistrar;
 	}
 
 	public function getClass(): string
@@ -86,6 +95,7 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
+			$this->registerExternalDependency();
 			$service = $this->serviceMap->getService($serviceId);
 			if ($service !== null && (!$service->isSynthetic() || $service->getClass() !== null)) {
 				return new ObjectType($this->determineServiceClass($parameterBag, $service) ?? $serviceId);
@@ -131,11 +141,19 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
+			$this->registerExternalDependency();
 			$service = $this->serviceMap->getService($serviceId);
 			return new ConstantBooleanType($service !== null && $service->isPublic());
 		}
 
 		return null;
+	}
+
+	private function registerExternalDependency(): void
+	{
+		if ($this->containerXmlPath !== null && $this->externalFileDependencyRegistrar !== null) {
+			$this->externalFileDependencyRegistrar->add($this->containerXmlPath);
+		}
 	}
 
 	private function determineServiceClass(ParameterBag $parameterBag, ServiceDefinition $service): ?string


### PR DESCRIPTION
## Summary

- Replace `SymfonyContainerResultCacheMetaExtension` (which caused full cache invalidation on any container change) with PHPStan's new external file dependency tracking
- When the container XML changes, only files that actually call `Container::get()`, `Container::has()`, `getParameter()`, or `hasParameter()` are re-analyzed instead of the entire project

## Motivation

The current `SymfonyContainerResultCacheMetaExtension` hashes the entire DI container state. Any change to any service definition invalidates the **entire** PHPStan result cache. On large Symfony projects with frequent service changes, this causes constant full re-analyses.

With this change, only the files that actually use the container (typically a few dozen controller/service files) are re-analyzed when the container XML changes — not the entire codebase.

See: phpstan/phpstan-symfony#455
Depends on: phpstan/phpstan-src#5364

## Changes

- `ServiceDynamicReturnTypeExtension`: registers container XML as external dependency when `Container::get()`/`has()` is called
- `ParameterDynamicReturnTypeExtension`: same for `getParameter()`/`hasParameter()`
- `ContainerInterfacePrivateServiceRule` / `ContainerInterfaceUnknownServiceRule`: same for rule checks
- `extension.neon`: passes `containerXmlPath` to extensions, removes `SymfonyContainerResultCacheMetaExtension`
- `rules.neon`: moves container rules to services with explicit `containerXmlPath` argument

All new parameters are nullable with defaults for backward compatibility with older PHPStan versions.

## Test plan

- [x] All 347 existing tests pass
- [ ] Integration test with actual cache invalidation scenario

Co-Authored-By: Claude Code