### PR TITLE
Remove unnecessary ServiceSubscriberInterface stub

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -26,7 +26,6 @@ parameters:
 		- stubs/Symfony/Component/Form/FormView.stub
 		- stubs/Symfony/Component/OptionsResolver/Exception/InvalidOptionsException.stub
 		- stubs/Symfony/Component/OptionsResolver/Options.stub
-		- stubs/Symfony/Contracts/Service/ServiceSubscriberInterface.stub
 
 parametersSchema:
 	symfony: structure([

--- a/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.stub
+++ b/stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.stub
@@ -4,9 +4,8 @@ namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
-use Symfony\Contracts\Service\ServiceSubscriberInterface;
 
-abstract class AbstractController implements ServiceSubscriberInterface
+abstract class AbstractController
 {
 	/**
 	 * @template TFormType of FormTypeInterface<TData>

--- a/stubs/Symfony/Contracts/Service/ServiceSubscriberInterface.stub
+++ b/stubs/Symfony/Contracts/Service/ServiceSubscriberInterface.stub
@@ -1,7 +1,0 @@
-<?php
-
-namespace Symfony\Contracts\Service;
-
-interface ServiceSubscriberInterface
-{
-}


### PR DESCRIPTION
This stub does not override any upstream types and is not necessary for the stubbed methods of AbstractController.