### PR TITLE
Add support for newer Symfony versions in tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,17 @@
     "phpstan/phpstan-phpunit": "^2.0.8",
     "phpstan/phpstan-strict-rules": "^2.0",
     "phpunit/phpunit": "^9.6",
-    "psr/container": "1.1.2",
-    "symfony/config": "^5.4 || ^6.1",
-    "symfony/console": "^5.4 || ^6.1",
-    "symfony/dependency-injection": "^5.4 || ^6.1",
-    "symfony/form": "^5.4 || ^6.1",
-    "symfony/framework-bundle": "^5.4 || ^6.1",
-    "symfony/http-foundation": "^5.4 || ^6.1",
-    "symfony/messenger": "^5.4",
+    "psr/container": "^1.1.2 || ^2.0",
+    "symfony/config": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/console": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/form": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/framework-bundle": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/http-foundation": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/messenger": "^5.4 || ^6.1 || ^7.0 || ^8.0",
     "symfony/polyfill-php80": "^1.24",
-    "symfony/serializer": "^5.4",
-    "symfony/service-contracts": "^2.2.0"
+    "symfony/serializer": "^5.4 || ^6.1 || ^7.0 || ^8.0",
+    "symfony/service-contracts": "^2.2.0 || ^3.0"
   },
   "config": {
     "sort-packages": true

--- a/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleFakeTest.php
+++ b/tests/Rules/Symfony/ContainerInterfacePrivateServiceRuleFakeTest.php
@@ -34,7 +34,10 @@ final class ContainerInterfacePrivateServiceRuleFakeTest extends RuleTestCase
 
 	public function testGetPrivateServiceInAbstractController(): void
 	{
-		if (!class_exists('Symfony\Bundle\FrameworkBundle\Controller\Controller')) {
+		if (!class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
+			self::markTestSkipped();
+		}
+		if (!method_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController', 'get')) {
 			self::markTestSkipped();
 		}
 		$this->analyse(

--- a/tests/Rules/Symfony/console_application_loader.php
+++ b/tests/Rules/Symfony/console_application_loader.php
@@ -6,5 +6,5 @@ use Symfony\Component\Console\Application;
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
 $application = new Application();
-$application->add(new ExampleCommand());
+$application->addCommands([new ExampleCommand()]);
 return $application;

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -52,6 +52,10 @@ class ExtensionTest extends TypeInferenceTestCase
 
 		if (class_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController')) {
 			yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractController.php');
+
+			if (method_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController', 'get')) {
+				yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractControllerServices.php');
+			}
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/serializer.php');

--- a/tests/Type/Symfony/ExtensionWithoutContainerTest.php
+++ b/tests/Type/Symfony/ExtensionWithoutContainerTest.php
@@ -24,6 +24,10 @@ class ExtensionWithoutContainerTest extends TypeInferenceTestCase
 		}
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractControllerWithoutContainer.php');
+
+		if (method_exists('Symfony\Bundle\FrameworkBundle\Controller\AbstractController', 'get')) {
+			yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractControllerServicesWithoutContainer.php');
+		}
 	}
 
 	/**

--- a/tests/Type/Symfony/console_application_loader.php
+++ b/tests/Type/Symfony/console_application_loader.php
@@ -10,14 +10,12 @@ use Symfony\Component\Console\Command\LazyCommand;
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
 $application = new Application();
-$application->add(new ExampleACommand());
-$application->add(new ExampleBCommand());
-$application->add(new ExampleOptionCommand());
+$application->addCommands([new ExampleACommand(), new ExampleBCommand(), new ExampleOptionCommand()]);
 
 if (class_exists(LazyCommand::class)) {
-	$application->add(new LazyCommand('lazy-example-option', [], '', false, static fn () => new ExampleOptionLazyCommand()));
+	$application->addCommands([new LazyCommand('lazy-example-option', [], '', false, static fn () => new ExampleOptionLazyCommand())]);
 } else {
-	$application->add(new ExampleOptionLazyCommand());
+	$application->addCommands([new ExampleOptionLazyCommand()]);
 }
 
 return $application;

--- a/tests/Type/Symfony/data/ExampleAbstractController.php
+++ b/tests/Type/Symfony/data/ExampleAbstractController.php
@@ -10,23 +10,6 @@ use function PHPStan\Testing\assertType;
 final class ExampleAbstractController extends AbstractController
 {
 
-	public function services(): void
-	{
-		assertType('Foo', $this->get('foo'));
-		assertType('Foo', $this->get('parameterised_foo'));
-		assertType('Foo\Bar', $this->get('parameterised_bar'));
-		assertType('Synthetic', $this->get('synthetic'));
-		assertType('object', $this->get('bar'));
-		assertType('object', $this->get(doFoo()));
-		assertType('object', $this->get());
-
-		assertType('true', $this->has('foo'));
-		assertType('true', $this->has('synthetic'));
-		assertType('false', $this->has('bar'));
-		assertType('bool', $this->has(doFoo()));
-		assertType('bool', $this->has());
-	}
-
 	public function parameters(ContainerInterface $container, ParameterBagInterface $parameterBag): void
 	{
 		assertType('array|bool|float|int|string|null', $container->getParameter('unknown'));

--- a/tests/Type/Symfony/data/ExampleAbstractControllerServices.php
+++ b/tests/Type/Symfony/data/ExampleAbstractControllerServices.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use function PHPStan\Testing\assertType;
+
+final class ExampleAbstractControllerServices extends AbstractController
+{
+
+	public function services(): void
+	{
+		assertType('Foo', $this->get('foo'));
+		assertType('Foo', $this->get('parameterised_foo'));
+		assertType('Foo\Bar', $this->get('parameterised_bar'));
+		assertType('Synthetic', $this->get('synthetic'));
+		assertType('object', $this->get('bar'));
+		assertType('object', $this->get(doFoo()));
+		assertType('object', $this->get());
+
+		assertType('true', $this->has('foo'));
+		assertType('true', $this->has('synthetic'));
+		assertType('false', $this->has('bar'));
+		assertType('bool', $this->has(doFoo()));
+		assertType('bool', $this->has());
+	}
+
+}

--- a/tests/Type/Symfony/data/ExampleAbstractControllerServicesWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleAbstractControllerServicesWithoutContainer.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Type\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use function PHPStan\Testing\assertType;
+
+final class ExampleAbstractControllerServicesWithoutContainer extends AbstractController
+{
+
+	public function services(): void
+	{
+		assertType('object', $this->get('foo'));
+		assertType('object', $this->get('synthetic'));
+		assertType('object', $this->get('bar'));
+		assertType('object', $this->get(doFoo()));
+		assertType('object', $this->get());
+
+		assertType('bool', $this->has('foo'));
+		assertType('bool', $this->has('synthetic'));
+		assertType('bool', $this->has('bar'));
+		assertType('bool', $this->has(doFoo()));
+		assertType('bool', $this->has());
+	}
+
+}

--- a/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
@@ -10,21 +10,6 @@ use function PHPStan\Testing\assertType;
 final class ExampleAbstractControllerWithoutContainer extends AbstractController
 {
 
-	public function services(): void
-	{
-		assertType('object', $this->get('foo'));
-		assertType('object', $this->get('synthetic'));
-		assertType('object', $this->get('bar'));
-		assertType('object', $this->get(doFoo()));
-		assertType('object', $this->get());
-
-		assertType('bool', $this->has('foo'));
-		assertType('bool', $this->has('synthetic'));
-		assertType('bool', $this->has('bar'));
-		assertType('bool', $this->has(doFoo()));
-		assertType('bool', $this->has());
-	}
-
 	public function parameters(ContainerInterface $container, ParameterBagInterface $parameterBag): void
 	{
 		assertType('array|bool|float|int|string|null', $container->getParameter('unknown'));


### PR DESCRIPTION
Symfony 5.4 is in security-only mode since years (and would already be EOL if its maintenance window had not been extended compared to the normal release schedule). Testing only Symfony 5.4 in CI does not reflect current usage of the extension.