### PR TITLE
Fix the tests running the extension without the container

### DIFF
--- a/tests/Type/Symfony/ExtensionWithoutContainerTest.php
+++ b/tests/Type/Symfony/ExtensionWithoutContainerTest.php
@@ -5,7 +5,7 @@ namespace PHPStan\Type\Symfony;
 use PHPStan\Testing\TypeInferenceTestCase;
 use function class_exists;
 
-class ExtensionTestWithoutContainer extends TypeInferenceTestCase
+class ExtensionWithoutContainerTest extends TypeInferenceTestCase
 {
 
 	public function dataExampleController(): iterable
@@ -14,7 +14,7 @@ class ExtensionTestWithoutContainer extends TypeInferenceTestCase
 			return;
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleController.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleControllerWithoutContainer.php');
 	}
 
 	public function dataAbstractController(): iterable
@@ -23,7 +23,7 @@ class ExtensionTestWithoutContainer extends TypeInferenceTestCase
 			return;
 		}
 
-		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractController.php');
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleAbstractControllerWithoutContainer.php');
 	}
 
 	/**

--- a/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleAbstractControllerWithoutContainer.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Symfony;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use function PHPStan\Testing\assertType;
 
 final class ExampleAbstractControllerWithoutContainer extends AbstractController
 {

--- a/tests/Type/Symfony/data/ExampleControllerWithoutContainer.php
+++ b/tests/Type/Symfony/data/ExampleControllerWithoutContainer.php
@@ -5,6 +5,7 @@ namespace PHPStan\Type\Symfony;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use function PHPStan\Testing\assertType;
 
 final class ExampleControllerWithoutContainer extends Controller
 {


### PR DESCRIPTION
PHPunit expects test classes to have a `Test` suffix in their name by default. Other classes are not loaded (considering they are utilities or fixtures for the tests instead).