### PR TITLE
Load more form stubs conditionally

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -13,9 +13,6 @@ parameters:
 	stubFiles:
 		- stubs/Symfony/Bundle/FrameworkBundle/Controller/AbstractController.stub
 		- stubs/Symfony/Component/Form/AbstractType.stub
-		- stubs/Symfony/Component/Form/Exception/ExceptionInterface.stub
-		- stubs/Symfony/Component/Form/Exception/RuntimeException.stub
-		- stubs/Symfony/Component/Form/Exception/TransformationFailedException.stub
 		- stubs/Symfony/Component/Form/FormBuilderInterface.stub
 		- stubs/Symfony/Component/Form/FormConfigBuilderInterface.stub
 		- stubs/Symfony/Component/Form/FormConfigInterface.stub

--- a/src/Stubs/Symfony/StubFilesExtensionLoader.php
+++ b/src/Stubs/Symfony/StubFilesExtensionLoader.php
@@ -60,6 +60,9 @@ class StubFilesExtensionLoader implements StubFilesExtension
 		}
 
 		if ($this->isInstalledVersionBelow('symfony/form', '6.2.0.0')) {
+			$files[] = $stubsDir . '/Symfony/Component/Form/Exception/ExceptionInterface.stub';
+			$files[] = $stubsDir . '/Symfony/Component/Form/Exception/RuntimeException.stub';
+			$files[] = $stubsDir . '/Symfony/Component/Form/Exception/TransformationFailedException.stub';
 			$files[] = $stubsDir . '/Symfony/Component/Form/DataTransformerInterface.stub';
 		}
 


### PR DESCRIPTION
~~The `FormView` has upstream types.~~ (needed as dependencies of form type stubs)
The exception stubs are only needed as dependencies of the `DataTransformerInterface` stubs.

I missed those in #481.