### PR TITLE
Remove Reflector from StubFilesExtensionLoader, replace with version checks

### DIFF
--- a/src/Stubs/Symfony/StubFilesExtensionLoader.php
+++ b/src/Stubs/Symfony/StubFilesExtensionLoader.php
@@ -4,8 +4,6 @@ namespace PHPStan\Stubs\Symfony;
 
 use Composer\InstalledVersions;
 use OutOfBoundsException;
-use PHPStan\BetterReflection\Reflector\Exception\IdentifierNotFound;
-use PHPStan\BetterReflection\Reflector\Reflector;
 use PHPStan\PhpDoc\StubFilesExtension;
 use function class_exists;
 use function dirname;
@@ -13,15 +11,6 @@ use function version_compare;
 
 class StubFilesExtensionLoader implements StubFilesExtension
 {
-
-	private Reflector $reflector;
-
-	public function __construct(
-		Reflector $reflector
-	)
-	{
-		$this->reflector = $reflector;
-	}
 
 	public function getFiles(): array
 	{
@@ -82,12 +71,9 @@ class StubFilesExtensionLoader implements StubFilesExtension
 		if ($this->isInstalledVersionBelow('symfony/http-foundation', '7.4.0.0')) {
 			$files[] = $stubsDir . '/Symfony/Component/HttpFoundation/ParameterBag.stub';
 
-			try {
-				$this->reflector->reflectClass('Symfony\Component\HttpFoundation\InputBag');
+			if (!$this->isInstalledVersionBelow('symfony/http-foundation', '5.1.0.0')) {
 				$files[] = $stubsDir . '/Symfony/Component/HttpFoundation/InputBag.stub';
 				$files[] = $stubsDir . '/Symfony/Component/HttpFoundation/Request.stub';
-			} catch (IdentifierNotFound $e) {
-				// Don't load the InputBag and the associated Request stubs for older Symfony versions that did not have InputBag yet to avoid breaking the Request.
 			}
 		}
 

--- a/src/Stubs/Symfony/StubFilesExtensionLoader.php
+++ b/src/Stubs/Symfony/StubFilesExtensionLoader.php
@@ -14,7 +14,7 @@ class StubFilesExtensionLoader implements StubFilesExtension
 
 	public function getFiles(): array
 	{
-		$stubsDir = dirname(dirname(dirname(__DIR__))) . '/stubs';
+		$stubsDir = dirname(__DIR__, 3) . '/stubs';
 		$files = [];
 
 		if ($this->isInstalledVersionBelow('symfony/security-bundle', '6.3.0.0')) {


### PR DESCRIPTION
The loader previously used BetterReflection's Reflector to check whether InputBag existed before loading its stubs. This triggered SourceLocator initialization (an expensive cache-populating operation) on every analysis run.

Replace the reflectClass() call with an isInstalledVersionBelow() version check (InputBag was introduced in symfony/http-foundation 5.1). Add a test that wires a ThrowingSourceLocator into the DI container's betterReflectionSourceLocator service, so any future regression that causes getFiles() to touch BetterReflection will fail the test explicitly.

--

Related:
- https://github.com/phpstan/phpstan-src/pull/5577
- https://github.com/phpstan/phpstan-src/pull/5538#issuecomment-4342781825