### PR TITLE
SymfonyContainerResultCacheMetaExtension optimization

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -312,5 +312,8 @@ services:
 
 	-
 		class: PHPStan\Symfony\SymfonyContainerResultCacheMetaExtension
+		arguments:
+			tmpDir: %tmpDir%
+			containerXmlPath: %symfony.containerXmlPath%
 		tags:
 			- phpstan.resultCacheMetaExtension

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -4,6 +4,7 @@ namespace PHPStan\Symfony;
 
 use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use function array_map;
+use function basename;
 use function file_get_contents;
 use function file_put_contents;
 use function hash;
@@ -44,23 +45,27 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 			if ($xmlHash === false) {
 				throw new XmlContainerNotExistsException(sprintf('Container %s does not exist', $this->containerXmlPath));
 			}
-			$hashFile = sprintf('%s/%s-%s.hash', $this->tmpDir, $this->getKey(), $xmlHash);
-			$hash = @file_get_contents($hashFile);
-			if ($hash !== false) {
-				return $hash;
+			$xmlHashFile = sprintf('%s/%s-%s.hash', $this->tmpDir, $this->getKey(), basename($this->containerXmlPath));
+			$storedXmlHash = @file_get_contents($xmlHashFile);
+
+			$hashForResultCacheFile = sprintf('%s/%s-%s-result-cache-meta.hash', $this->tmpDir, $this->getKey(), basename($this->containerXmlPath));
+			$storedHashForResultCache = @file_get_contents($hashForResultCacheFile);
+			if ($storedXmlHash === $xmlHash && $storedHashForResultCache !== false) {
+				return $storedHashForResultCache;
 			}
 		}
 
-		$hash = $this->calculateHash();
+		$hashForResultCache = $this->calculateHash();
 
 		if ($this->containerXmlPath !== null) {
-			file_put_contents($hashFile, $hash);
+			file_put_contents($hashForResultCacheFile, $hashForResultCache);
+			file_put_contents($xmlHashFile, $xmlHash);
 		}
 
-		return $hash;
+		return $hashForResultCache;
 	}
 
-	public function calculateHash(): string
+	private function calculateHash(): string
 	{
 		$services = $parameters = [];
 

--- a/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
+++ b/src/Symfony/SymfonyContainerResultCacheMetaExtension.php
@@ -4,9 +4,13 @@ namespace PHPStan\Symfony;
 
 use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
 use function array_map;
+use function file_get_contents;
+use function file_put_contents;
 use function hash;
+use function hash_file;
 use function ksort;
 use function sort;
+use function sprintf;
 use function var_export;
 
 final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaExtension
@@ -16,10 +20,16 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 
 	private ServiceMap $serviceMap;
 
-	public function __construct(ParameterMap $parameterMap, ServiceMap $serviceMap)
+	private string $tmpDir;
+
+	private ?string $containerXmlPath;
+
+	public function __construct(ParameterMap $parameterMap, ServiceMap $serviceMap, string $tmpDir, ?string $containerXmlPath)
 	{
 		$this->parameterMap = $parameterMap;
 		$this->serviceMap = $serviceMap;
+		$this->tmpDir = $tmpDir;
+		$this->containerXmlPath = $containerXmlPath;
 	}
 
 	public function getKey(): string
@@ -28,6 +38,29 @@ final class SymfonyContainerResultCacheMetaExtension implements ResultCacheMetaE
 	}
 
 	public function getHash(): string
+	{
+		if ($this->containerXmlPath !== null) {
+			$xmlHash = hash_file('sha256', $this->containerXmlPath);
+			if ($xmlHash === false) {
+				throw new XmlContainerNotExistsException(sprintf('Container %s does not exist', $this->containerXmlPath));
+			}
+			$hashFile = sprintf('%s/%s-%s.hash', $this->tmpDir, $this->getKey(), $xmlHash);
+			$hash = @file_get_contents($hashFile);
+			if ($hash !== false) {
+				return $hash;
+			}
+		}
+
+		$hash = $this->calculateHash();
+
+		if ($this->containerXmlPath !== null) {
+			file_put_contents($hashFile, $hash);
+		}
+
+		return $hash;
+	}
+
+	public function calculateHash(): string
 	{
 		$services = $parameters = [];
 

--- a/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
+++ b/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
@@ -54,16 +54,22 @@ final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 
 		$hash = $extension->getHash();
 
-		$cacheFile = sprintf('%s/symfonyDiContainer-c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f.hash', $this->tmpDir);
-		self::assertFileExists($cacheFile);
-		self::assertSame($hash, file_get_contents($cacheFile));
+		$resultCacheHashFile = sprintf('%s/symfonyDiContainer-container.xml-result-cache-meta.hash', $this->tmpDir);
+		self::assertFileExists($resultCacheHashFile);
+		self::assertSame($hash, file_get_contents($resultCacheHashFile));
+
+		$xmlHashFile = sprintf('%s/symfonyDiContainer-container.xml.hash', $this->tmpDir);
+		self::assertFileExists($xmlHashFile);
+		self::assertSame('c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f', file_get_contents($xmlHashFile));
 	}
 
 	public function testCachedHashIsReturnedOnCacheHit(): void
 	{
 		$containerXmlPath = __DIR__ . '/container.xml';
-		$cacheFile = sprintf('%s/symfonyDiContainer-c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f.hash', $this->tmpDir);
-		file_put_contents($cacheFile, 'pre-computed-hash');
+		$xmlHashFile = sprintf('%s/symfonyDiContainer-container.xml.hash', $this->tmpDir);
+		file_put_contents($xmlHashFile, 'c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f');
+		$resultCacheHashFile = sprintf('%s/symfonyDiContainer-container.xml-result-cache-meta.hash', $this->tmpDir);
+		file_put_contents($resultCacheHashFile, 'pre-computed-hash');
 
 		$extension = new SymfonyContainerResultCacheMetaExtension(
 			new DefaultParameterMap([]),

--- a/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
+++ b/tests/Symfony/SymfonyContainerResultCacheMetaExtensionTest.php
@@ -4,12 +4,76 @@ namespace PHPStan\Symfony;
 
 use PHPStan\Testing\PHPStanTestCase;
 use function count;
+use function file_get_contents;
+use function file_put_contents;
+use function glob;
+use function mkdir;
+use function rmdir;
+use function sprintf;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
 
 /**
  * @phpstan-type ContainerContents array{parameters?: ParameterMap, services?: ServiceMap}
  */
 final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 {
+
+	private string $tmpDir;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+		$this->tmpDir = sys_get_temp_dir() . '/phpstan-symfony-test-' . uniqid('', true);
+		mkdir($this->tmpDir, 0777, true);
+	}
+
+	protected function tearDown(): void
+	{
+		$cacheFiles = glob($this->tmpDir . '/*.hash');
+		if ($cacheFiles !== false) {
+			foreach ($cacheFiles as $file) {
+				unlink($file);
+			}
+		}
+		rmdir($this->tmpDir);
+		parent::tearDown();
+	}
+
+	public function testHashIsCalculatedAndWrittenToCacheFileOnCacheMiss(): void
+	{
+		$containerXmlPath = __DIR__ . '/container.xml';
+
+		$extension = new SymfonyContainerResultCacheMetaExtension(
+			new DefaultParameterMap([]),
+			new DefaultServiceMap([]),
+			$this->tmpDir,
+			$containerXmlPath,
+		);
+
+		$hash = $extension->getHash();
+
+		$cacheFile = sprintf('%s/symfonyDiContainer-c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f.hash', $this->tmpDir);
+		self::assertFileExists($cacheFile);
+		self::assertSame($hash, file_get_contents($cacheFile));
+	}
+
+	public function testCachedHashIsReturnedOnCacheHit(): void
+	{
+		$containerXmlPath = __DIR__ . '/container.xml';
+		$cacheFile = sprintf('%s/symfonyDiContainer-c55d6ac45b535d6ecc9402cbb93825c38ec7b11b03f66577d0d3549b3d9ef75f.hash', $this->tmpDir);
+		file_put_contents($cacheFile, 'pre-computed-hash');
+
+		$extension = new SymfonyContainerResultCacheMetaExtension(
+			new DefaultParameterMap([]),
+			new DefaultServiceMap([]),
+			$this->tmpDir,
+			$containerXmlPath,
+		);
+
+		self::assertSame('pre-computed-hash', $extension->getHash());
+	}
 
 	/**
 	 * @param list<ContainerContents> $sameHashContents
@@ -30,6 +94,8 @@ final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 			$currentHash = (new SymfonyContainerResultCacheMetaExtension(
 				$content['parameters'] ?? new DefaultParameterMap([]),
 				$content['services'] ?? new DefaultServiceMap([]),
+				__DIR__ . '/../../tmp',
+				null,
 			))->getHash();
 
 			if ($hash === null) {
@@ -44,6 +110,8 @@ final class SymfonyContainerResultCacheMetaExtensionTest extends PHPStanTestCase
 			(new SymfonyContainerResultCacheMetaExtension(
 				$invalidatingContent['parameters'] ?? new DefaultParameterMap([]),
 				$invalidatingContent['services'] ?? new DefaultServiceMap([]),
+				__DIR__ . '/../../tmp',
+				null,
 			))->getHash(),
 		);
 	}


### PR DESCRIPTION
The cache busting strategy implemented by the extension attempts to avoid unnecessary invalidations by calculating the hash from the parsed parameters and services used within phpstan-symfony logic. This addresses the case when the container XML have been regenerated and changed, but not in an significant way impacting the result cache (originally discussed in https://github.com/phpstan/phpstan-symfony/issues/255).

The problem is that on large DI containers this parsing, normalizing and hashing is not exactly cheap:

<img width="664" height="395" alt="Scrn_20260509_103902" src="https://github.com/user-attachments/assets/96abd01a-020b-416b-8312-27da6eaf0740" />

This PR adds a simple filesytem cache for the calculated hash to avoid this cost - the hash is recalculated from the parsed services/parameters only when the underlying XML changes.