### PR TITLE
Update release-toot.yml

### DIFF
--- a/.github/workflows/release-toot.yml
+++ b/.github/workflows/release-toot.yml
@@ -21,6 +21,5 @@ jobs:
           # GitHub event payload
           # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#release
           message: "New release: ${{ github.event.repository.name }} ${{ github.event.release.tag_name }} ${{ github.event.release.html_url }} #phpstan"
-        env:
-          MASTODON_URL: https://phpc.social
-          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          url: https://phpc.social
+          access-token: ${{ secrets.MASTODON_ACCESS_TOKEN }}


### PR DESCRIPTION
copied this change from the phpstan repo.. maybe this fixes the toot error on releases

<img width="1139" height="423" alt="grafik" src="https://github.com/user-attachments/assets/121413ac-9f5a-451e-bdd6-bc719720cf12" />

Todo
- [ ] port to other repos, after we verified it works