### PR TITLE
Precise Uid::toString return type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "ext-simplexml": "*",
-    "phpstan/phpstan": "^2.1.13"
+    "phpstan/phpstan": "^2.2.0"
   },
   "conflict": {
     "symfony/framework-bundle": "<3.0"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
     "symfony/messenger": "^5.4",
     "symfony/polyfill-php80": "^1.24",
     "symfony/serializer": "^5.4",
-    "symfony/service-contracts": "^2.2.0"
+    "symfony/service-contracts": "^2.2.0",
+    "symfony/uid": "^5.4.0"
   },
   "config": {
     "sort-packages": true

--- a/src/Stubs/Symfony/StubFilesExtensionLoader.php
+++ b/src/Stubs/Symfony/StubFilesExtensionLoader.php
@@ -142,6 +142,10 @@ class StubFilesExtensionLoader implements StubFilesExtension
 			$files[] = $stubsDir . '/Symfony/Component/Serializer/Normalizer/NormalizerInterface.stub';
 		}
 
+		if ($this->isInstalledVersionBelow('symfony/uuid', '8.2.0.0')) {
+			$files[] = $stubsDir . '/Symfony/Component/Uid/AbstractUuid.stub';
+		}
+
 		if ($this->isInstalledVersionBelow('symfony/validator', '5.4.0.0')) {
 			$files[] = $stubsDir . '/Symfony/Component/Validator/ConstraintViolationInterface.stub';
 			$files[] = $stubsDir . '/Symfony/Component/Validator/ConstraintViolationListInterface.stub';

--- a/stubs/Symfony/Component/Uid/AbstractUid.stub
+++ b/stubs/Symfony/Component/Uid/AbstractUid.stub
@@ -1,0 +1,41 @@
+<?php
+
+use Symfony\Component\Uid\Exception\InvalidArgumentException;
+
+abstract class AbstractUid
+{
+    /**
+     * @var non-empty-string&non-decimal-int-string
+     */
+    protected string $uid;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+	 */
+	public function toRfc4122(): string;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+	 */
+	public function toHex(): string;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+	 */
+	public function hash(): string;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+	 */
+	final public function toString(): string;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+     */
+	public function __toString(): string;
+
+    /**
+     * @return non-empty-string&non-decimal-int-string
+     */
+	public function jsonSerialize(): string;
+}

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -76,6 +76,8 @@ class ExtensionTest extends TypeInferenceTestCase
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor/WithConfigurationWithConstructorExtension.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor-optional-params/WithConfigurationWithConstructorOptionalParamsExtension.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/extension/with-configuration-with-constructor-required-params/WithConfigurationWithConstructorRequiredParamsExtension.php');
+
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/uid.php');
 	}
 
 	/**

--- a/tests/Type/Symfony/data/uid.php
+++ b/tests/Type/Symfony/data/uid.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace UuidStub;
+
+use Symfony\Component\Uid\Uuid;
+use function PHPStan\Testing\assertType;
+
+$uuid = new Uuid::v4();
+
+assertType('non-empty-string&non-decimal-int-string', $uuid->toRfc4122());
+assertType('non-empty-string&non-decimal-int-string', $uuid->toHex());
+assertType('non-empty-string&non-decimal-int-string', $uuid->hash());
+assertType('non-empty-string&non-decimal-int-string', $uuid->toString());
+assertType('non-empty-string&non-decimal-int-string', $uuid->jsonSerialize());


### PR DESCRIPTION
Related to https://github.com/symfony/symfony/pull/64450

This require to bump the lower version of PHPStan unless PHPStan has a new version which parse `non-decimal-int-string` and `decimal-int-string` as `string`.