### PR TITLE
Default FormType data to mixed

### DIFF
--- a/stubs/Symfony/Component/Form/AbstractType.stub
+++ b/stubs/Symfony/Component/Form/AbstractType.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  *
  * @implements FormTypeInterface<TData>
  */

--- a/stubs/Symfony/Component/Form/FormBuilderInterface.stub
+++ b/stubs/Symfony/Component/Form/FormBuilderInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  *
  * @extends \Traversable<int, \Symfony\Component\Form\FormBuilderInterface<mixed>>
  * @extends FormConfigBuilderInterface<TData>

--- a/stubs/Symfony/Component/Form/FormConfigBuilderInterface.stub
+++ b/stubs/Symfony/Component/Form/FormConfigBuilderInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  *
  * @extends FormConfigInterface<TData>
  */

--- a/stubs/Symfony/Component/Form/FormConfigInterface.stub
+++ b/stubs/Symfony/Component/Form/FormConfigInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  */
 interface FormConfigInterface
 {

--- a/stubs/Symfony/Component/Form/FormInterface.stub
+++ b/stubs/Symfony/Component/Form/FormInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  *
  * @extends \ArrayAccess<string, \Symfony\Component\Form\FormInterface<mixed>>
  * @extends \Traversable<string, \Symfony\Component\Form\FormInterface<mixed>>

--- a/stubs/Symfony/Component/Form/FormTypeExtensionInterface.stub
+++ b/stubs/Symfony/Component/Form/FormTypeExtensionInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  */
 interface FormTypeExtensionInterface
 {

--- a/stubs/Symfony/Component/Form/FormTypeInterface.stub
+++ b/stubs/Symfony/Component/Form/FormTypeInterface.stub
@@ -3,7 +3,7 @@
 namespace Symfony\Component\Form;
 
 /**
- * @template TData
+ * @template TData = mixed
  */
 interface FormTypeInterface
 {


### PR DESCRIPTION
The same form type can be used with an `object` or if no data is set unstructured array `array<string, mixed>` or a none compound simple type `string`, `bool`, ...

So the best default to not annoy here is set TData to mixed, still all existing can say they only accept specific data.

In most cases form types not accessing data in them so this mostly unused generic type. Only a few form types accessing data directly.