### PR TITLE
Do not resolve ServiceLocator get()/has() against the global container

### DIFF
--- a/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
+++ b/src/Rules/Symfony/ContainerInterfaceUnknownServiceRule.php
@@ -50,6 +50,14 @@ final class ContainerInterfaceUnknownServiceRule implements Rule
 			return [];
 		}
 
+		// A ServiceLocator is a scoped locator: its keys are local (e.g. tag index
+		// attributes from #[AutowireLocator]), not global container service ids, so the
+		// ServiceMap has no knowledge of them and cannot tell whether they are registered.
+		$isServiceLocatorType = (new ObjectType('Symfony\Component\DependencyInjection\ServiceLocator'))->isSuperTypeOf($argType);
+		if ($isServiceLocatorType->yes()) {
+			return [];
+		}
+
 		$isControllerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\Controller'))->isSuperTypeOf($argType);
 		$isAbstractControllerType = (new ObjectType('Symfony\Bundle\FrameworkBundle\Controller\AbstractController'))->isSuperTypeOf($argType);
 		$isContainerType = (new ObjectType('Symfony\Component\DependencyInjection\ContainerInterface'))->isSuperTypeOf($argType);

--- a/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
+++ b/src/Type/Symfony/ServiceDynamicReturnTypeExtension.php
@@ -129,6 +129,14 @@ final class ServiceDynamicReturnTypeExtension implements DynamicMethodReturnType
 			return null;
 		}
 
+		// A ServiceLocator is a scoped locator: its keys are local (e.g. tag index
+		// attributes from #[AutowireLocator]), not global container service ids. The
+		// ServiceMap only knows the global container, so it cannot decide has() here;
+		// returning a constant bool would wrongly make guard branches unreachable.
+		if ((new ObjectType('Symfony\Component\DependencyInjection\ServiceLocator'))->isSuperTypeOf($scope->getType($methodCall->var))->yes()) {
+			return null;
+		}
+
 		$serviceId = $this->serviceMap::getServiceIdFromNode($methodCall->getArgs()[0]->value, $scope);
 		if ($serviceId !== null) {
 			$service = $this->serviceMap->getService($serviceId);

--- a/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
+++ b/tests/Rules/Symfony/ContainerInterfaceUnknownServiceRuleTest.php
@@ -71,6 +71,20 @@ final class ContainerInterfaceUnknownServiceRuleTest extends RuleTestCase
 		);
 	}
 
+	public function testServiceLocatorKeyIsNotReportedAsUnknownService(): void
+	{
+		if (!class_exists('Symfony\Component\DependencyInjection\ServiceLocator')) {
+			self::markTestSkipped('The test needs Symfony\Component\DependencyInjection\ServiceLocator class.');
+		}
+
+		$this->analyse(
+			[
+				__DIR__ . '/ExampleServiceLocatorConsumer.php',
+			],
+			[],
+		);
+	}
+
 	public static function getAdditionalConfigFiles(): array
 	{
 		return [

--- a/tests/Rules/Symfony/ExampleServiceLocatorConsumer.php
+++ b/tests/Rules/Symfony/ExampleServiceLocatorConsumer.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Rules\Symfony;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+
+final class ExampleServiceLocatorConsumer
+{
+
+	/**
+	 * @param ServiceLocator<object> $locator
+	 */
+	public function __construct(private readonly ServiceLocator $locator)
+	{
+	}
+
+	public function run(): void
+	{
+		// "unknown" is not a global container service id, but it is a valid locator
+		// index key (e.g. from #[AutowireLocator]), so no serviceNotFound must be reported.
+		$this->locator->get('unknown');
+	}
+
+}

--- a/tests/Type/Symfony/ExtensionTest.php
+++ b/tests/Type/Symfony/ExtensionTest.php
@@ -33,6 +33,8 @@ class ExtensionTest extends TypeInferenceTestCase
 
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/tree_builder.php');
 
+		yield from $this->gatherAssertTypes(__DIR__ . '/data/service_locator.php');
+
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleBaseCommand.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleOptionCommand.php');
 		yield from $this->gatherAssertTypes(__DIR__ . '/data/ExampleOptionLazyCommand.php');

--- a/tests/Type/Symfony/data/service_locator.php
+++ b/tests/Type/Symfony/data/service_locator.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+namespace SymfonyServiceLocator;
+
+use Symfony\Component\DependencyInjection\ServiceLocator;
+use function PHPStan\Testing\assertType;
+
+interface HandlerInterface
+{
+
+	public function handle(): void;
+
+}
+
+class Consumer
+{
+
+	/**
+	 * @param ServiceLocator<HandlerInterface> $locator
+	 */
+	public function __construct(
+		private readonly ServiceLocator $locator,
+	)
+	{
+	}
+
+	public function run(string $key): void
+	{
+		// has() on a ServiceLocator must NOT collapse to a constant bool: a locator key
+		// is a local index, not a global service id, so the ServiceMap cannot decide it.
+		// Otherwise a `if (!$locator->has('x')) { return; }` guard would be seen as
+		// "always true" and everything after it as unreachable.
+		assertType('bool', $this->locator->has($key));
+		assertType('bool', $this->locator->has('some_index'));
+	}
+
+}


### PR DESCRIPTION
`ServiceDynamicReturnTypeExtension` and `ContainerInterfaceUnknownServiceRule` are registered for `Psr\Container\ContainerInterface`, which also matches an injected `Symfony\Component\DependencyInjection\ServiceLocator` (e.g. from `#[AutowireLocator]`). A locator's keys are **local index keys** (tag index attributes), not global container service ids — but both consulted the global `ServiceMap`.

Consequences for a `ServiceLocator`:

- `has('key')` collapsed to a constant `false` (the key isn't a global service id), so `if (!$locator->has('key')) { return; }` became *"always true"* and the rest of the method **unreachable**;
- `get('key')` was wrongly reported with `symfonyContainer.serviceNotFound`.

This PR skips `ServiceLocator` receivers in both places, leaving `get()`/`has()` to native (generic) inference. The global container, controllers, and Psr-typed `ServiceSubscriber` locators are unaffected (a `ServiceLocator` is not their static type; the existing `testGetPrivateServiceInLegacyServiceSubscriber` still passes).

Discovered via shipmonk-rnd/dead-code-detector#376 — the unreachable code led a dead-code detector to report the handler methods behind the locator as unused. Repro & analysis: https://github.com/shipmonk-rnd/dead-code-detector/issues/376#issuecomment-5002396100
